### PR TITLE
RAC-198 fix: 토큰 받아오는 로직 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
     <html lang="ko">
       <body>
         <Providers>
-          <Token />
+          {/* <Token /> */}
           {children}
           <div id="senior-info-portal"></div>
           <div id="junior-mentoring-detail"></div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -5,29 +5,38 @@ import CustomerCenter from '@/components/Profile/ProfileStateChange/CustomerCent
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import useAuth from '@/hooks/useAuth';
+import { useAtomValue } from 'jotai';
+import { accessTokenAtom } from '@/stores/user';
 
-function page() {
+function MyPage() {
   const [nickName, setnickName] = useState<string | null>(null);
   const [profile, setprofile] = useState<string | null>(null);
+  const Token = useAtomValue(accessTokenAtom);
   const { getAccessToken } = useAuth();
+
   useEffect(() => {
-    if (getAccessToken()) {
-      const Token = getAccessToken();
-      const headers = {
-        Authorization: `Bearer ${Token}`,
-      };
-      axios
-        .get(`${process.env.NEXT_PUBLIC_SERVER_URL}/user/me`, { headers })
-        .then((data) => {
-          setnickName(data.data.data.nickName);
-          setprofile(data.data.data.profile);
-        })
-        .catch(function (error) {
-          console.log(error);
-        });
-    } else {
+    async function getMyPage() {
+      await getAccessToken();
+      if (Token) {
+        const headers = {
+          Authorization: `Bearer ${Token}`,
+        };
+        axios
+          .get(`${process.env.NEXT_PUBLIC_SERVER_URL}/user/me`, { headers })
+          .then((data) => {
+            setnickName(data.data.data.nickName);
+            setprofile(data.data.data.profile);
+          })
+          .catch(function (error) {
+            console.log(error);
+          });
+      } else {
+      }
     }
-  }, []);
+
+    getMyPage();
+    
+  }, [Token]);
 
   return (
     <div>
@@ -41,4 +50,4 @@ function page() {
   );
 }
 
-export default page;
+export default MyPage;


### PR DESCRIPTION
## 🦝 PR 요약
- 토큰 받아오는 로직이 제대로 동작하지 않아 수정했는데 hotfix라고 생각해서 먼저 머지합니다!ㅠㅠ

## ✨ PR 상세 내용
- `useAuth` hook에서 access token을 받아오는 로직이 제대로 동작하지 않는 문제 발견
- 함수들을 비동기로 바꿔보는 등 여러 시도를 했는데 해결 안 됨...
- 원인은 **Jotai store에 token을 setting하는 코드가 비동기적으로 동작해서**인 것 같습니다
- 그래서 Jotai store에 token을 정상적으로 저장했음에도 불구하고 제가 토큰을 받아올 때는 동기화가 안 되어서 그런 것 같아요...
- 근데 **원인은 찾았는데 근본적인 해결 방법은 못 찾은 상황**...입니다
- 그래도 스피디하게 개발하는 게 먼저라고 생각해서 차선책으로 수정했습니다
- 이렇게 되면 `layout.tsx`의 `Token` 컴포넌트는 실행하나 마나인 것 같아서 주석처리 해두긴 했는데 굳이 지우진 않았습니다...!

## 🚨 주의 사항
- **앞으로 토큰을 받아올 때 다음의 과정을 따라 주세요!(`/mypage/page.tsx` 파일 참고)**
1. `useAuth`의 `getAccessToken()`의 리턴값으로 토큰을 바로 받아오지 말고, 해당 함수는 jotai store에 token을 세팅하는 기능을 수행한다고 생각
2. token을 사용하고자 하는 파일에서 `accessTokenAtom`을 직접 get 해 옴
3. `useEffect()` 2번째 인자인 의존성 배열에 이 token 변수를 넣어서, 이 token 변수 값이 변했을 때(즉, 토큰값이 제대로 들어왔을 때) api 요청하도록 변경

- **근본적인 해결방법은 나중에 찾아보도록 하겠습니다.....**
- **이거 RAC-190에 머지되면 바로 main에 반영할게요...!!!**

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
