### PR TITLE
fix: 소셜 로그인 로컬/개발 api 구분 및 userType 불러오는 부분 수정

### DIFF
--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -15,15 +15,15 @@ function KakaoPage() {
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get('code');
     axios
-      .post(`${process.env.NEXT_PUBLIC_SERVER_URL}/auth/login/KAKAO`, {
+      .post(window.location.hostname.includes('localhost') ? `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/dev/login/KAKAO` : `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/login/KAKAO`, {
         code: code,
       })
       .then((res) => {
         const response = res.data;
         if (response.code == 'AU205') {
           // router.replace(`/signup/${response.data.socialId}`);
-          router.replace('signup/select');
           setSocialId(response.data.socialId);
+          router.push('/signup/select');
           return;
         }
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -61,7 +61,7 @@ function MyPage() {
 
   useEffect(() => {
     const userT = getUserType();
-      if(userT) setUserType(userT);
+    if(userT) setUserType(userT);
  }, []);
 
   useEffect(() => {
@@ -110,7 +110,7 @@ function MyPage() {
           });
       }
     }
-  }, [Token]);
+  }, [Token, userType]);
 
   return (
     <div style={{ backgroundColor: '#F8F9FA', width: 'inherit' }}>

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -13,6 +13,7 @@ import {
 } from './Profile.styled';
 import { ProfileProps } from '@/types/profile/profile';
 import SingleValidator from '../Validator/SingleValidator';
+import user_icon from '../../../public/user.png';
 
 function Profile(props: ProfileProps) {
   const suggestModal = () => {
@@ -24,7 +25,7 @@ function Profile(props: ProfileProps) {
     <ProfileBox>
       <ImageBox>
         <Image
-          src={profile}
+          src={props.profile || user_icon}
           alt="profile image"
           width={52}
           height={52}

--- a/src/components/kakao/login.tsx
+++ b/src/components/kakao/login.tsx
@@ -2,15 +2,32 @@
 import React, { useEffect, useState } from 'react';
 import useAuth from '@/hooks/useAuth';
 const REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY;
-const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
+// const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
 
 function Login() {
   const { getAccessToken } = useAuth();
   const [token, setToken] = useState<string | null | undefined>('');
-  const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+  // const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
   const loginHandler = () => {
-    window.location.href = link;
+    // console.log(window.location.hostname);
+    // window.location.href = link;
+    if(typeof window !== undefined) {
+      if(window.location.hostname.includes('localhost')) {
+        const REDIRECT_URI = process.env.NEXT_PUBLIC_LOCAL_REDIRECT_URI;
+        const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+        window.location.href = link;
+      }
+      else {
+        const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
+        const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+        window.location.href = link;
+      }
+    } else {
+      const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
+      const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+      window.location.href = link;
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 🦝 PR 요약
- 소셜 로그인 로컬/개발 api 분리한 거 반영
- 로컬에서는 잘 돌아가는데 개발서버에서도 잘 돌아가나 확인하기 위해 머지합니다!

## ✨ PR 상세 내용
+) `Profile` 부분 userType에 따라 로직 다르게 실행할 때 `useEffect` 의존성 배열에 `userType` 추가해야 하는데 놓친 것 같아서 겸사겸사 수정했습니다

## 🚨 주의 사항
- **이게 개발 서버에서도 잘 동작하는지 확인하면 `kakao/login.tsx` 말고도 로그인 수행할 수 있는 부분 다 이와 같이 수정해 줘야 합니다! 잊어버릴 수도 있을 것 같아 적어둡니다**

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
