### PR TITLE
RAC-295 fix: 멘토링 신청 결제 생략 및 주제&사전질문 입력내용 불러오기

### DIFF
--- a/src/app/mentoring-apply/[seniorId]/pay/page.tsx
+++ b/src/app/mentoring-apply/[seniorId]/pay/page.tsx
@@ -246,7 +246,13 @@ function MentoringApplyPayPage() {
         >
           이전
         </button>
-        <button id="map-next-btn" className="map-btn" onClick={() => {router.push('/mentoring-apply/done');}}>
+        <button
+          id="map-next-btn"
+          className="map-btn"
+          onClick={() => {
+            router.push('/mentoring-apply/done');
+          }}
+        >
           결제하기
         </button>
       </MAPBtnContainer>

--- a/src/app/senior/edit-profile/page.tsx
+++ b/src/app/senior/edit-profile/page.tsx
@@ -150,7 +150,7 @@ function EditProfilePage() {
           <BtnBox>
             <MBtnFont>
               연구실명&nbsp;<div id="font-color">*</div>
-             {flag &&  <div id="warn-msg">&nbsp;연구실명을 입력해주세요</div>}
+              {flag && <div id="warn-msg">&nbsp;연구실명을 입력해주세요</div>}
             </MBtnFont>
             <TextForm
               placeholder={sLab ? sLab : '연구실 이름을 입력해주세요.'}
@@ -160,7 +160,9 @@ function EditProfilePage() {
           <BtnBox>
             <MBtnFont>
               연구분야&nbsp;<div id="font-color">*</div>
-              {flag && <div id="warn-msg">&nbsp;최소 1개 이상 선택해주세요</div>}
+              {flag && (
+                <div id="warn-msg">&nbsp;최소 1개 이상 선택해주세요</div>
+              )}
             </MBtnFont>
             <ModalBtn
               type="seniorInfo"
@@ -174,7 +176,9 @@ function EditProfilePage() {
           <BtnBox>
             <MBtnFont>
               연구주제&nbsp;<div id="font-color">*</div>
-              {flag && <div id="warn-msg">&nbsp;최소 1개 이상 입력해주세요</div>}
+              {flag && (
+                <div id="warn-msg">&nbsp;최소 1개 이상 입력해주세요</div>
+              )}
             </MBtnFont>
             <ModalBtn
               type="seniorInfo"
@@ -269,7 +273,9 @@ function EditProfilePage() {
             }}
           >
             <div id="setData-title">가능 정기일정</div>
-            {flag &&<div id="setData-warn">최소 3개 이상 일정을 추가해주세요</div>}
+            {flag && (
+              <div id="setData-warn">최소 3개 이상 일정을 추가해주세요</div>
+            )}
           </div>
           <SetDataBox>
             {timeData.length > 0 ? (

--- a/src/app/senior/info/[seniorId]/page.tsx
+++ b/src/app/senior/info/[seniorId]/page.tsx
@@ -38,34 +38,35 @@ function SeniorInfoPage() {
 
     const seniorId = pathArr[pathArr.length - 1];
     setFindSeniorId(seniorId);
-    if(token){
-    axios
-      .get(`${process.env.NEXT_PUBLIC_SERVER_URL}/senior/${seniorId}`, {
-        headers,
-      })
-      .then((response) => {
-        const res = response.data;
+    if (token) {
+      axios
+        .get(`${process.env.NEXT_PUBLIC_SERVER_URL}/senior/${seniorId}`, {
+          headers,
+        })
+        .then((response) => {
+          const res = response.data;
 
-        if (res.code == 'SNR200') {
-          setMine(res.data.isMine);
-          setInfo(res.data.info);
-          setKeyword(res.data.keyword);
-          setLab(res.data.lab);
-          setMajor(res.data.major);
-          setNickName(res.data.nickName);
-          setOneLiner(res.data.oneLiner);
-          setPostgradu(res.data.postgradu);
-          setProfessor(res.data.professor);
-          setProfile(res.data.profile);
-          setTarget(res.data.target);
-          setTerm(res.data.term);
-          setTimes(res.data.times);
-        }
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-  }}, []);
+          if (res.code == 'SNR200') {
+            setMine(res.data.isMine);
+            setInfo(res.data.info);
+            setKeyword(res.data.keyword);
+            setLab(res.data.lab);
+            setMajor(res.data.major);
+            setNickName(res.data.nickName);
+            setOneLiner(res.data.oneLiner);
+            setPostgradu(res.data.postgradu);
+            setProfessor(res.data.professor);
+            setProfile(res.data.profile);
+            setTarget(res.data.target);
+            setTerm(res.data.term);
+            setTimes(res.data.times);
+          }
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
+  }, []);
 
   const applyHandler = () => {
     const accessTkn = getAccessToken();

--- a/src/app/signup/select/common-info/auth/page.tsx
+++ b/src/app/signup/select/common-info/auth/page.tsx
@@ -63,7 +63,7 @@ function AuthPage() {
       </div>
       <div style={{ marginLeft: '1rem' }}>
         <h3 style={{ marginTop: '1.25rem' }}>대학원생임을 인증해주세요!</h3>
-                <AuthFont>
+        <AuthFont>
           대학원 선배 회원으로 가입하면 멘토링을 진행할 수 있어요
         </AuthFont>
         <br />

--- a/src/components/Content/LoginRequest/LoginRequest.tsx
+++ b/src/components/Content/LoginRequest/LoginRequest.tsx
@@ -13,13 +13,12 @@ const REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY;
 function LoginRequest(props: loginRequestProps) {
   const handleClick = () => {
     props.modalHandler();
-    if(typeof window !== undefined) {
-      if(window.location.hostname.includes('localhost')) {
+    if (typeof window !== undefined) {
+      if (window.location.hostname.includes('localhost')) {
         const REDIRECT_URI = process.env.NEXT_PUBLIC_LOCAL_REDIRECT_URI;
         const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
         window.location.href = link;
-      }
-      else {
+      } else {
         const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
         const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
         window.location.href = link;

--- a/src/components/Content/MyLoginRequest/MyLoginRequest.tsx
+++ b/src/components/Content/MyLoginRequest/MyLoginRequest.tsx
@@ -16,13 +16,12 @@ const REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY;
 function MyLoginRequest({ modalHandler }: { modalHandler: () => void }) {
   const handleClick = () => {
     modalHandler();
-    if(typeof window !== undefined) {
-      if(window.location.hostname.includes('localhost')) {
+    if (typeof window !== undefined) {
+      if (window.location.hostname.includes('localhost')) {
         const REDIRECT_URI = process.env.NEXT_PUBLIC_LOCAL_REDIRECT_URI;
         const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
         window.location.href = link;
-      }
-      else {
+      } else {
         const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
         const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
         window.location.href = link;

--- a/src/components/LogoLayer/LogoLayer.tsx
+++ b/src/components/LogoLayer/LogoLayer.tsx
@@ -14,7 +14,7 @@ function LogoLayer(props: SearchModalProps) {
   useEffect(() => {
     const accessTkn = getAccessToken();
 
-    if(accessTkn) {
+    if (accessTkn) {
       setIsLogin(true);
     }
   }, []);

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -23,7 +23,7 @@ function Scheduler() {
   const clickHandler = (removeIdx: number) => {
     setTimeData(timeData.filter((_, idx) => idx !== removeIdx));
   };
-  const formatTime = (time:string) => {
+  const formatTime = (time: string) => {
     const [hours, minutes] = time.split(':');
     return `${hours}시 ${minutes}분`;
   };
@@ -52,7 +52,8 @@ function Scheduler() {
               {timeData.map((el, idx) => (
                 <SchedulerEl key={idx}>
                   <div id="scheduler-el-time">
-                  {el.day}요일 {formatTime(el.startTime)} ~ {formatTime(el.endTime)}
+                    {el.day}요일 {formatTime(el.startTime)} ~{' '}
+                    {formatTime(el.endTime)}
                   </div>
                   <div
                     id="scheduler-el-remove-btn"

--- a/src/components/SingleForm/TextareaForm/TextareaForm.tsx
+++ b/src/components/SingleForm/TextareaForm/TextareaForm.tsx
@@ -10,9 +10,11 @@ function TextareaForm(props: TextareaFormProps) {
   const [content, setContent] = useAtom(props.targetAtom);
 
   useEffect(() => {
-    if(content) {
-      const formEl = document.getElementById(`textarea-${props.targetAtom.toString()}`) as HTMLTextAreaElement;
-      if(formEl) formEl.value = content;
+    if (content) {
+      const formEl = document.getElementById(
+        `textarea-${props.targetAtom.toString()}`,
+      ) as HTMLTextAreaElement;
+      if (formEl) formEl.value = content;
     }
   }, []);
 

--- a/src/components/kakao/login.tsx
+++ b/src/components/kakao/login.tsx
@@ -8,8 +8,8 @@ function Login() {
   const [token, setToken] = useState<string | null | undefined>('');
 
   const loginHandler = () => {
-    if(typeof window !== undefined) {
-      if(window.location.hostname.includes('localhost')) {
+    if (typeof window !== undefined) {
+      if (window.location.hostname.includes('localhost')) {
         const REDIRECT_URI = process.env.NEXT_PUBLIC_LOCAL_REDIRECT_URI;
         const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
         window.location.href = link;

--- a/src/lib/registry.tsx
+++ b/src/lib/registry.tsx
@@ -1,29 +1,29 @@
-'use client'
- 
-import React, { useState } from 'react'
-import { useServerInsertedHTML } from 'next/navigation'
-import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
- 
+'use client';
+
+import React, { useState } from 'react';
+import { useServerInsertedHTML } from 'next/navigation';
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
+
 export default function StyledComponentsRegistry({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   // Only create stylesheet once with lazy initial state
   // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
-  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet())
- 
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
   useServerInsertedHTML(() => {
-    const styles = styledComponentsStyleSheet.getStyleElement()
-    styledComponentsStyleSheet.instance.clearTag()
-    return <>{styles}</>
-  })
- 
-  if (typeof window !== 'undefined') return <>{children}</>
- 
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== 'undefined') return <>{children}</>;
+
   return (
     <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
       {children}
     </StyleSheetManager>
-  )
+  );
 }


### PR DESCRIPTION
## 🦝 PR 요약
- 멘토링 신청 결제 임시 생략
- 주제 및 사전질문 입력 내용 불러오는 기능 추가

## ✨ PR 상세 내용
- 기획팀에서 QA를 위해 멘토링 신청에서 결제 건너뛰고 바로 완료 화면으로 건너가게끔 임시로 바꿔달라고 해서 반영했습니다!
- 이것만 구현해서 올리기 좀 그래서 멘토링 신청 페이지 버그를 하나 수정했습니다! 멘토링 신청에서 "주제"랑 "사전질문" 작성하고 일정 선택으로 넘어가는데, 거기서 이전 버튼을 누르면 사용자가 작성했던 주제랑 사전질문이 화면에 반영이 안 되고 있었습니다. 그래서 jotai에서 사용자가 작성해놓은 주제랑 사전질문 있으면 화면에 불러오는 기능 추가로 구현했습니다!

## 🚨 주의 사항
- **format fix 실행했더니 파일이 많이 바뀌어버렸는데, 그냥 `TextareaForm` 컴포넌트랑 `app/mentoring-apply/[seniorId]/question` 파일만 봐주시면 됩니다!!!!`

## 📸 스크린샷

<img width="445" alt="image" src="https://github.com/WE-ARE-RACCOONS/postgraduate-front/assets/50830078/9584a484-cff3-4c0f-afe5-802bd0b8628e">

화면은 딱히 바뀐 부분 없습니다!

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
