### PR TITLE
RAC-313 hotfix: 로그인 로직 수정

### DIFF
--- a/src/components/Content/LoginRequest/LoginRequest.tsx
+++ b/src/components/Content/LoginRequest/LoginRequest.tsx
@@ -14,7 +14,7 @@ function LoginRequest(props: loginRequestProps) {
   const handleClick = () => {
     props.modalHandler();
     if (typeof window !== undefined) {
-      const REDIRECT_URI = window.location.href + 'login/oauth2/code/kakao';
+      const REDIRECT_URI = window.location.origin + '/login/oauth2/code/kakao';
       const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
       window.location.href = link;
     }

--- a/src/components/Content/MentoringLogin/MentoringLogin.tsx
+++ b/src/components/Content/MentoringLogin/MentoringLogin.tsx
@@ -8,7 +8,7 @@ function MentoringLogin({ modalHandler }: { modalHandler: () => void }) {
   const handleClick = () => {
     modalHandler();
     if (typeof window !== undefined) {
-      const REDIRECT_URI = window.location.href + 'login/oauth2/code/kakao';
+      const REDIRECT_URI = window.location.origin + '/login/oauth2/code/kakao';
       const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
       window.location.href = link;
     }

--- a/src/components/Content/MyLoginRequest/MyLoginRequest.tsx
+++ b/src/components/Content/MyLoginRequest/MyLoginRequest.tsx
@@ -17,7 +17,7 @@ function MyLoginRequest({ modalHandler }: { modalHandler: () => void }) {
   const handleClick = () => {
     modalHandler();
     if (typeof window !== undefined) {
-      const REDIRECT_URI = window.location.href + 'login/oauth2/code/kakao';
+      const REDIRECT_URI = window.location.origin + '/login/oauth2/code/kakao';
       const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
       window.location.href = link;
     }

--- a/src/components/kakao/login.tsx
+++ b/src/components/kakao/login.tsx
@@ -9,7 +9,7 @@ function Login() {
 
   const loginHandler = () => {
     if (typeof window !== undefined) {
-      const REDIRECT_URI = window.location.href + 'login/oauth2/code/kakao';
+      const REDIRECT_URI = window.location.origin + '/login/oauth2/code/kakao';
       const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
       window.location.href = link;
     }


### PR DESCRIPTION
## 🦝 PR 요약
- 로그인 로직 수정한 거 hotfix 합니다!

## ✨ PR 상세 내용
- 기존에 현재 url 뒤에 `/login/oauth2/code/kakao` 붙이는 걸로 했는데 이러면 루트 경로가 아니라 다른 경로에 있을 때 path가 더 붙어버려서 `origin`에 붙여주는 걸로 수정했습니다!

## 🚨 주의 사항
- hotfix라 바로 merge합니다!!

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
