### PR TITLE
RAC-329 hotfix: 내멘토링 시간 오류 수정

### DIFF
--- a/src/components/Mentoring/MentoringApply/MentoringApply.tsx
+++ b/src/components/Mentoring/MentoringApply/MentoringApply.tsx
@@ -44,6 +44,7 @@ function MentoringApply({ data }: MentoringApplyProps) {
   const userType = getUserType();
 
   const formatRemainTime = (remainTime: string) => {
+    if(!remainTime) return '0시간 0분';
     const splittedTime = remainTime.split('-');
     return `${splittedTime[0]}시간 ${splittedTime[1]}분 `;
   };
@@ -64,6 +65,7 @@ function MentoringApply({ data }: MentoringApplyProps) {
   };
 
   const convertDateType = (date: string) => {
+    if(!date) return new Date();
     const parts = date.split('-');
     const year = parseInt(parts[0]);
     const month = parseInt(parts[1]) - 1;


### PR DESCRIPTION
## 🦝 PR 요약
- 내멘토링 시간 오류 수정

## ✨ PR 상세 내용
- 만약에 ① `진행예정`만 있거나 ② `확정대기`만 있거나 ③ `완료`만 있을 때 등등은 `remainTime`이나 `date` 값이 없을 수도 있는데 그 부분 예외처리가 안 된 것 같아서 발생한 문제인 것 같습니다!
- 예를 들어, `확정대기`만 있는 경우면 서버로부터 오는 데이터에 `remainTime`이 없을 텐데 지금 코드는 데이터 없어도 컴포넌트가 한 번 떴다 사라지는? 그런 식으로 구현이 되어 있어서 없는 데이터에 일단 접근하는데 데이터가 없을 때 예외처리 해주는 부분이 없었던 것 같아서 추가했어요!!!

## 🚨 주의 사항
- hotfix라 바로 main까지 merge합니다!

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
