### PR TITLE
RAC-333 fix: 선배 재인증&전환&회원가입 새로고침 및 토큰 문제 수정

### DIFF
--- a/src/app/signup/select/common-info/auth/page.tsx
+++ b/src/app/signup/select/common-info/auth/page.tsx
@@ -19,8 +19,9 @@ import { certifiRegAtom } from '@/stores/signup';
 function AuthPage() {
   const [uploadFlag, setUploadFlag] = useState(false);
   const [photo, setPhoto] = useState<File | null>(null);
-  const { getAccessToken } = useAuth();
+  const { getAccessToken, getUserType } = useAuth();
   const [accessTkn, setAccessTkn] = useState<string | null | undefined>('');
+  const [userType, setUserType] = useState('');
   const setphotoUrl = useSetAtom(photoUrlAtom);
   const router = useRouter();
   const fileName = photo?.name;
@@ -30,10 +31,18 @@ function AuthPage() {
     getAccessToken().then((tkn) => {
       setAccessTkn(tkn);
     });
+    const userT = getUserType();
+    if (userT) setUserType(userT);
   }, []);
 
   useEffect(() => {
-    detectReload();
+    const entries = performance.getEntriesByType('navigation')[0];
+    const entriesNavTiming = entries as PerformanceNavigationTiming;
+
+    if (entriesNavTiming.type == 'reload') {
+      if(!accessTkn) window.location.href = window.location.origin + '/signup/select'; // 선배 최초 회원가입
+      else window.location.href = window.location.origin + '/signup/select/common-info/auth'; // 후배 -> 선배 전환 or 선배 재인증
+    }
 
     (() => {
       window.addEventListener('beforeunload', preventClose);
@@ -49,7 +58,7 @@ function AuthPage() {
       setUploadFlag(false);
       const formData = new FormData();
       formData.append('certificationFile', photo);
-      if (certifiReg === 'NOT_APPROVE') {
+      if (certifiReg === 'NOT_APPROVE' || (accessTkn && userType == 'senior')) {
         axios
           .patch(
             `${process.env.NEXT_PUBLIC_SERVER_URL}/senior/certification`,
@@ -109,7 +118,7 @@ function AuthPage() {
     <div>
       <div>
         <BackHeader headerText="인증하기" />
-        {(certifiReg !== 'NOT_APPROVE') && <ProgressBar totalNum={4} activeNum={0} />}
+        {(userType && userType == 'senior') && <ProgressBar totalNum={4} activeNum={0} />}
       </div>
       <div style={{ marginLeft: '1rem' }}>
         <h3 style={{ marginTop: '1.25rem' }}>대학원생임을 인증해주세요!</h3>


### PR DESCRIPTION
## 🦝 PR 요약
- 선배 재인증&전환&회원가입 로직 다듬었어요

## ✨ PR 상세 내용
![image](https://github.com/WE-ARE-RACCOONS/postgraduate-front/assets/50830078/a92a6599-453f-4a46-82c3-9cdf504368d0)

새로고침 하면 `certifiReg` 값이 날아가기 때문에 localStorage에 있는 토큰과 userType을 추가로 조건에 넣었습니당

‼️ 새로고침의 경우,
- 토큰이 없으면, `선배 최초 회원가입`이므로 새로고침 시에 `/signup/select`로 이동
- 토큰이 있으면, `후배->선배 전환`이거나 `선배 재인증`인데 둘 다 `/auth` 페이지에 있어야 해서 그 페이지에서 새로고침

그리고 `certifiReg=='NOT_APPROVE'`이거나 `토큰이 있고, userType이 senior`면 "선배 재인증"이고,
아니면 나머지 경우라서 api 분기 이렇게 나눠줬구요

`ProgreeBar`의 경우, 선배 재인증 페이지에서는 안 보여야 해서 토큰과 userType으로 조건 추가했습니다!

이해 어려운 부분이나 틀린 부분 있으면 말씀해주세용!!

## 🚨 주의 사항
겹치는 부분이라 한 명이 얼른 수정해서 올리는 게 나을 것 같아서 일단 PR 올립니닷 !!

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
