### PR TITLE
RAC-338 fix: GA 운영서버에만 동작하는 로직 수정

### DIFF
--- a/src/components/GA/GA.jsx
+++ b/src/components/GA/GA.jsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 function GoogleAnalytics() {
   useEffect(() => {
-    if (process.env.NODE_ENV == 'production') {
+    if (window.location.hostname.includes('kimseonbae')) {
       window.dataLayer = window.dataLayer || [];
       function gtag() {
         window.dataLayer.push(arguments);


### PR DESCRIPTION
## 🦝 PR 요약

## ✨ PR 상세 내용
- 운영 서버에서만 동작하도록 `window.location.hostname`으로 구분

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
