### PR TITLE
🌿 RAC-339 fix: 모달에서 인증 및 선배전환으로 이동하는 경로 수정

### DIFF
--- a/src/components/Modal/NotSenior/NotSenior.tsx
+++ b/src/components/Modal/NotSenior/NotSenior.tsx
@@ -24,8 +24,9 @@ function NotSenior(props: NotSeniorProps) {
   };
 
   const router = useRouter();
+
   const seniorJoin = () => {
-    router.push(`/signup/select/common-info/auth`);
+    router.push(`/signup/select/common-info/major`);
   };
 
   return (

--- a/src/components/SuggestModal/SuggestModal.tsx
+++ b/src/components/SuggestModal/SuggestModal.tsx
@@ -15,7 +15,7 @@ interface SuggestModalProps {
 function SuggestModal(props: SuggestModalProps) {
   const router = useRouter();
   const seniorAuth = () => {
-    router.push(`/signup/select/common-info/auth`);
+    router.push(`/senior/auth`);
   };
   const ProfileinfoHandler = () => {
     router.push(`/senior/edit-profile`);


### PR DESCRIPTION
## 🦝 PR 요약
- 모달에서 이동하는 경로 수정

## ✨ PR 상세 내용
- 모달에서 "선배 인증"이나 "후배->선배 전환"으로 이동하는 경우 경로가 바뀌어야 해서 수정합니다!

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
