### PR TITLE
RAC-395 feat: 대학원생 인증유무 마크 표시

### DIFF
--- a/src/components/SeniorProfile/SeniorProfile.tsx
+++ b/src/components/SeniorProfile/SeniorProfile.tsx
@@ -34,7 +34,11 @@ function SeniorProfile({ data }: SeniorProfileProps) {
           </SPmajor>
           <SPnickname>
             {data.nickName ? data.nickName : ''}
-            {data.certification ? <Image src={auth} alt="auth" width={16} height={16} /> :''}
+            {data.certification ? (
+              <Image src={auth} alt="auth" width={16} height={16} />
+            ) : (
+              ''
+            )}
           </SPnickname>
           <SPField>{data.lab ? data.lab : ''}</SPField>
         </SeniorProfileInfo>

--- a/src/components/SeniorProfile/SeniorProfile.tsx
+++ b/src/components/SeniorProfile/SeniorProfile.tsx
@@ -34,7 +34,7 @@ function SeniorProfile({ data }: SeniorProfileProps) {
           </SPmajor>
           <SPnickname>
             {data.nickName ? data.nickName : ''}
-            <Image src={auth} alt="auth" width={16} height={16} />
+            {data.certification ? <Image src={auth} alt="auth" width={16} height={16} /> :''}
           </SPnickname>
           <SPField>{data.lab ? data.lab : ''}</SPField>
         </SeniorProfileInfo>


### PR DESCRIPTION
## 🦝 PR 요약
대학원생 인증유무 마크 표시
## ✨ PR 상세 내용
certification을 이용해 certification이 true일때만 인증마크가 나타나게 변경
대학원생 인증유무 마크 표시
## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
