### PR TITLE
RAC-408 fix: 멘토링 진행X 후배 내멘토링 페이지 UI 수정

### DIFF
--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.styled.ts
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.styled.ts
@@ -6,6 +6,7 @@ interface TapStyleProps {
 
 export const TabResult = styled.div`
   border-top: 1px solid #c2cede;
+  min-height: 100vh;
   height: auto;
   padding-bottom: 4rem;
 `;

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -28,6 +28,7 @@ import findExCode from '@/utils/findExCode';
 import { JMCancelAtom } from '@/stores/condition';
 import { REVIEW_FORM_URL } from '@/constants/form/reviewForm';
 import { StyledSModalBtn } from '@/components/Button/ModalBtn/ModalBtn.styled';
+import MentoringNotYet from '@/components/MentoringNotYet';
 
 function convertDateType(date: string) {
   if (!date) return new Date();
@@ -197,7 +198,7 @@ function TabBar() {
             );
           })
         ) : (
-          <NoMentoring>{TAB_STATE[activeTab]}인 멘토링이 없어요</NoMentoring>
+          <MentoringNotYet />
         )}
       </div>
     );

--- a/src/components/Bar/TapBar/SeniorTab/STabBrar.styled.ts
+++ b/src/components/Bar/TapBar/SeniorTab/STabBrar.styled.ts
@@ -56,6 +56,7 @@ export const TabResultContainer = styled.div`
 `;
 export const TabResult = styled.div`
   border-top: 1px solid #c2cede;
+  min-height: 100vh;
   height: auto;
   padding-bottom: 4rem;
 `;

--- a/src/components/Bar/TapBar/SeniorTab/STabBrar.styled.ts
+++ b/src/components/Bar/TapBar/SeniorTab/STabBrar.styled.ts
@@ -30,6 +30,7 @@ export const NoMentoring = styled.div`
   line-height: 140%; /* 1.4rem */
   display: flex;
   justify-content: center;
+  margin-top: 1rem;
 `;
 export const DoneBtnBox = styled.div`
   width: 19.4375rem;

--- a/src/components/Card/IntroCard/IntroCard.styled.ts
+++ b/src/components/Card/IntroCard/IntroCard.styled.ts
@@ -34,6 +34,7 @@ export const IntroCardTextBox = styled.div<{ $isFull: boolean }>`
   margin-bottom: 2.5rem;
   white-space: pre-wrap;
   word-wrap: break-word;
+  line-height: 130%;
 `;
 
 export const IntroCardTextDesc = styled.div`

--- a/src/components/MentoringNotYet/MentoringNotYet.styled.ts
+++ b/src/components/MentoringNotYet/MentoringNotYet.styled.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const MentoringNotYetContainer = styled.div`
+  height: 15.25rem;
+  white-space: pre;
+  line-height: 140%;
+  color: #939393;
+  text-align: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  #logo-img {
+    opacity: 0.6;
+    width: 6.125rem;
+    height: auto;
+    margin-bottom: 1rem;
+  }
+
+  button {
+    width: 15.1875rem;
+    height: 3.1875rem;
+    background-color: #2fc4b2;
+    color: #fff;
+    border-radius: 0.5rem;
+    border: none;
+    font-size: 1.25rem;
+    font-weight: 600;
+    font-family: Pretendard;
+    margin-top: 3rem;
+  }
+`;

--- a/src/components/MentoringNotYet/MentoringNotYet.tsx
+++ b/src/components/MentoringNotYet/MentoringNotYet.tsx
@@ -1,0 +1,16 @@
+import { MENTORING_NOT_YET } from '@/constants/mentoring/my';
+import { MentoringNotYetContainer } from './MentoringNotYet.styled';
+import Image from 'next/image';
+import logo from '../../../public/logo.png';
+
+function MentoringNotYet() {
+  return (
+    <MentoringNotYetContainer>
+      <Image id="logo-img" src={logo} alt="대학원 김선배 로고 이미지" />
+      <p>{MENTORING_NOT_YET.msg}</p>
+      <button>{MENTORING_NOT_YET.btnText}</button>
+    </MentoringNotYetContainer>
+  );
+}
+
+export default MentoringNotYet;

--- a/src/components/MentoringNotYet/index.tsx
+++ b/src/components/MentoringNotYet/index.tsx
@@ -1,0 +1,3 @@
+import MentoringNotYet from './MentoringNotYet';
+
+export default MentoringNotYet;

--- a/src/constants/mentoring/my.ts
+++ b/src/constants/mentoring/my.ts
@@ -1,0 +1,4 @@
+export const MENTORING_NOT_YET = {
+  msg: `아직 진행된 멘토링이 없어요!\n내가 원하는 선배를 찾고 멘토링을 진행해 보세요:)`,
+  btnText: '멘토링 신청 하러 가기',
+};


### PR DESCRIPTION
## 🦝 PR 요약
멘토링 진행X 후배 내멘토링 페이지 UI 수정

## ✨ PR 상세 내용
- 멘토링 진행하지 않은 '후배' 회원 내멘토링 페이지 UI 수정
- 후배, 선배 내멘토링 페이지에서 값이 없을 때 height가 짧게 나오는 문제가 있길래 min-height 부여해줌
- 저번 회의에서 얘기 나왔던 선배 상세페이지 행간 늘림

## 🚨 주의 사항

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/db11b9de-a98d-4088-a588-ecdaebcb30d2)

![image](https://github.com/user-attachments/assets/b667d4d8-0f26-4b53-8593-ddb373fe8dec)
![image](https://github.com/user-attachments/assets/b37b7830-74a3-4f3a-8ffe-0838c1fffa39)

위에서 아래로 바꿨는데(행간 130%) 좀 미묘한 것 같기도... 그래도 너무 늘리면 또 가독성 안 좋은 것 같아서 일단 130% 정도로 했습니다!!


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
