### PR TITLE
RAC-413 fix: 교수님 필드 수정 및 회원가입 상수화

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
 
     const infiniteBottom = () => {
       let isScrollAtBottom =
-        window.innerHeight + window.scrollY >= document.body.offsetHeight;
+        window.innerHeight + window.scrollY >= document.body.offsetHeight - 5;
       if (isScrollAtBottom) {
         axios
           .get(
@@ -73,11 +73,9 @@ export default function Home() {
     };
 
     window.addEventListener('scroll', infiniteBottom);
-    window.addEventListener('touchmove', infiniteBottom);
 
     return () => {
       window.removeEventListener('scroll', infiniteBottom);
-      window.removeEventListener('touchmove', infiniteBottom);
     };
   }, [page]);
 

--- a/src/app/search-results/page.tsx
+++ b/src/app/search-results/page.tsx
@@ -57,7 +57,7 @@ function SearchResultPage() {
   useEffect(() => {
     const infiniteBottom = () => {
       let isScrollAtBottom =
-        window.innerHeight + window.scrollY >= document.body.offsetHeight - 1;
+        window.innerHeight + window.scrollY >= document.body.offsetHeight - 5;
       if (isScrollAtBottom) {
         let url = `${process.env.NEXT_PUBLIC_SERVER_URL}/senior/search?find=${searchTerm}`;
         if (sort) {
@@ -83,11 +83,9 @@ function SearchResultPage() {
     };
 
     window.addEventListener('scroll', infiniteBottom);
-    window.addEventListener('touchmove', infiniteBottom);
 
     return () => {
       window.removeEventListener('scroll', infiniteBottom);
-      window.removeEventListener('touchmove', infiniteBottom);
     };
   }, [page]);
 

--- a/src/app/signup/select/common-info/matching-info/page.tsx
+++ b/src/app/signup/select/common-info/matching-info/page.tsx
@@ -16,6 +16,7 @@ import NextBtn from '@/components/Button/NextBtn';
 import { useEffect } from 'react';
 import { detectReload, preventClose } from '@/utils/reloadFun';
 import { useRouter } from 'next/navigation';
+import { JUNIOR_MATCHING } from '@/constants/signup/junior';
 
 function MatchingInfoPage() {
   const router = useRouter();
@@ -48,26 +49,26 @@ function MatchingInfoPage() {
       </div>
       <div style={{ marginLeft: '1rem', marginTop: '1.5rem' }}>
         <h3 style={{ marginBottom: '0.5rem' }}>
-          김선배가 딱 맞는 선배를 찾아드려요
+          {JUNIOR_MATCHING.matchingTitle}
         </h3>
         <MIFont>
-          찾고 있는 대학원 선배에 대해 알려주시면
+          {JUNIOR_MATCHING.matchingDescFir}
           <br />
-          김선배가 딱 맞는 선배가 있을 때 알림톡을 드려요!
+          {JUNIOR_MATCHING.matchingDescSec}
         </MIFont>
         <MatchingForm
-          title="희망 대학원/학과"
+          title={JUNIOR_MATCHING.desiredSchoolTitle}
           isRequired={false}
           maxLength={50}
-          placeholder={`예시)연세대학원/컴퓨터과학과\n카이스트 대학원/생명화학공학과`}
+          placeholder={JUNIOR_MATCHING.desiredSchoolPlaceholder}
           handler={setDesiredSchool}
           charCount={schoolCharCount}
         />
         <MatchingForm
-          title="희망 연구분야/교수님"
+          title={JUNIOR_MATCHING.desiredFieldTitle}
           isRequired={false}
           maxLength={60}
-          placeholder={`예시)나노 소재/홍길동 교수님\n반도체 소자/아무개 교수님`}
+          placeholder={JUNIOR_MATCHING.desiredFieldPlaceholder}
           handler={setDesiredField}
           charCount={fieldCharCount}
         />
@@ -83,7 +84,7 @@ function MatchingInfoPage() {
             checked={matchingReceive}
             onChange={handleMatchingReceive}
           />
-          <MILabel>(선택) 나에게 맞는 선배를 알림톡으로 받아볼래요!</MILabel>
+          <MILabel>{JUNIOR_MATCHING.matchingReceiveText}</MILabel>
         </div>
         {(matchingReceive ? schoolCharCount && fieldCharCount : true) ? (
           <SignUpBtn />

--- a/src/app/signup/select/common-info/matching-info/page.tsx
+++ b/src/app/signup/select/common-info/matching-info/page.tsx
@@ -16,7 +16,6 @@ import NextBtn from '@/components/Button/NextBtn';
 import { useEffect } from 'react';
 import { detectReload, preventClose } from '@/utils/reloadFun';
 import { useRouter } from 'next/navigation';
-import GoogleAnalytics from '@/components/GA/GA';
 
 function MatchingInfoPage() {
   const router = useRouter();
@@ -44,7 +43,6 @@ function MatchingInfoPage() {
 
   return (
     <div>
-      {/* <GoogleAnalytics /> */}
       <div style={{ boxShadow: '0px 4px 8px 0px rgba(0, 0, 0, 0.10)' }}>
         <BackHeader headerText="회원가입" />
       </div>
@@ -87,7 +85,7 @@ function MatchingInfoPage() {
           />
           <MILabel>(선택) 나에게 맞는 선배를 알림톡으로 받아볼래요!</MILabel>
         </div>
-        {schoolCharCount && fieldCharCount ? (
+        {(matchingReceive ? schoolCharCount && fieldCharCount : true) ? (
           <SignUpBtn />
         ) : (
           <NextBtn kind="route-non-matching" btnText="가입완료 하기" />

--- a/src/app/signup/select/common-info/senior-info/field/page.tsx
+++ b/src/app/signup/select/common-info/senior-info/field/page.tsx
@@ -24,6 +24,7 @@ import BackHeader from '@/components/Header/BackHeader';
 import ProgressBar from '@/components/Bar/ProgressBar';
 import findExCode from '@/utils/findExCode';
 import { detectReload, preventClose } from '@/utils/reloadFun';
+import { SENIOR_FIELD } from '@/constants/signup/senior';
 
 function SeniorInfoPage() {
   const [modalType, setModalType] = useState<ModalType>('postgradu');
@@ -235,30 +236,34 @@ function SeniorInfoPage() {
       </div>
       <ProgressBar totalNum={4} activeNum={2} />
       <SeniorInfoPageContainer>
-        <h3>소속 중인 연구실에 대해 알려주세요.</h3>
+        <h3>{SENIOR_FIELD.fieldTitle}</h3>
         <SIFormTitleContainer>
           <SIFormTitle>
-            <div className="si-form-title-text">연구분야&nbsp;</div>
+            <div className="si-form-title-text">{SENIOR_FIELD.field}&nbsp;</div>
             <div className="si-form-title-star">*</div>
           </SIFormTitle>
           {sField && <SIModifyBtn onClick={fieldHandler}>수정</SIModifyBtn>}
         </SIFormTitleContainer>
         <SIFormBox $isNotEmpty={sField ? true : false}>
           <div className="si-form-select-text">
-            {sField ? formatField(sField) : `선택된 연구분야가 없습니다.`}
+            {sField ? formatField(sField) : SENIOR_FIELD.fieldPlaceholder}
           </div>
           {!sField && <SIAddBtn onClick={fieldHandler}>+ 추가하기</SIAddBtn>}
         </SIFormBox>
         <SIFormTitleContainer>
           <SIFormTitle>
-            <div className="si-form-title-text">연구주제&nbsp;</div>
+            <div className="si-form-title-text">
+              {SENIOR_FIELD.keyword}&nbsp;
+            </div>
             <div className="si-form-title-star">*</div>
           </SIFormTitle>
           {sKeyword && <SIModifyBtn onClick={keywordHandler}>수정</SIModifyBtn>}
         </SIFormTitleContainer>
         <SIFormBox $isNotEmpty={sKeyword ? true : false}>
           <div className="si-form-select-text">
-            {sKeyword ? formatKeyword(sKeyword) : '선택된 연구주제가 없습니다.'}
+            {sKeyword
+              ? formatKeyword(sKeyword)
+              : SENIOR_FIELD.keywordPlaceholder}
           </div>
           {!sKeyword && (
             <SIAddBtn onClick={keywordHandler}>+ 추가하기</SIAddBtn>

--- a/src/app/signup/select/common-info/senior-info/lab/page.tsx
+++ b/src/app/signup/select/common-info/senior-info/lab/page.tsx
@@ -17,6 +17,7 @@ import styled from 'styled-components';
 import BackHeader from '@/components/Header/BackHeader';
 import ProgressBar from '@/components/Bar/ProgressBar';
 import { detectReload, preventClose } from '@/utils/reloadFun';
+import { SENIOR_LAB } from '@/constants/signup/senior';
 
 function SeniorInfoPage() {
   const [emptyPart, setEmptyPart] = useState('');
@@ -71,24 +72,24 @@ function SeniorInfoPage() {
       </div>
       <SeniorInfoPageContainer>
         <BtnContainer>
-          <h3>연구실 정보를 알려주세요.</h3>
+          <h3>{SENIOR_LAB.labTitle}</h3>
           <BtnBox>
             <MBtnFont>
-              지도교수님&nbsp;<div id="font-color">*</div>
+              {SENIOR_LAB.professor}&nbsp;<div id="font-color">*</div>
             </MBtnFont>
             <TextForm
               max={10}
-              placeholder="지도교수님 성함을 입력해주세요."
+              placeholder={SENIOR_LAB.professorPlaceholder}
               targetAtom="professor"
             />
           </BtnBox>
           <BtnBox>
             <MBtnFont>
-              연구실명&nbsp;<div id="font-color">*</div>
+              {SENIOR_LAB.lab}&nbsp;<div id="font-color">*</div>
             </MBtnFont>
             <TextForm
               max={30}
-              placeholder="연구실 이름을 입력해주세요."
+              placeholder={SENIOR_LAB.labPlaceholder}
               targetAtom="lab"
             />
           </BtnBox>

--- a/src/app/signup/select/common-info/senior-info/major/page.tsx
+++ b/src/app/signup/select/common-info/senior-info/major/page.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 import BackHeader from '@/components/Header/BackHeader';
 import ProgressBar from '@/components/Bar/ProgressBar';
 import { detectReload, preventClose } from '@/utils/reloadFun';
+import { SENIOR_MAJOR } from '@/constants/signup/senior';
 
 function SeniorInfoPage() {
   const [modalType, setModalType] = useState<ModalType>('postgradu');
@@ -64,21 +65,21 @@ function SeniorInfoPage() {
       </div>
       <SeniorInfoPageContainer>
         <SICBox>
-          <h3>선배 정보를 입력해주세요</h3>
-          <div id="info-content-msg">
-            입력한 정보는 멘토링 매칭에 이용됩니다.
-          </div>
+          <h3>{SENIOR_MAJOR.seniorInfoTitle}</h3>
+          <div id="info-content-msg">{SENIOR_MAJOR.seniorInfoUsage}</div>
         </SICBox>
         <BtnContainer>
-          <h3>대학원 정보를 알려주세요.</h3>
+          <h3>{SENIOR_MAJOR.graduateSchoolTitle}</h3>
           <BtnBox>
             <MBtnFont>
-              대학원&nbsp;<div id="font-color">*</div>
+              {SENIOR_MAJOR.graduateSchool}&nbsp;<div id="font-color">*</div>
             </MBtnFont>
             <ModalBtn
               $isGet={!sPostGradu}
               type="seniorInfo"
-              btnText={sPostGradu ? sPostGradu : '대학원을 선택해주세요.'}
+              btnText={
+                sPostGradu ? sPostGradu : SENIOR_MAJOR.graduateSchoolPlaceholder
+              }
               modalHandler={modalHandler}
               onClick={() => {
                 setModalType('postgradu');
@@ -87,12 +88,12 @@ function SeniorInfoPage() {
           </BtnBox>
           <BtnBox>
             <MBtnFont>
-              학과&nbsp;<div id="font-color">*</div>
+              {SENIOR_MAJOR.major}&nbsp;<div id="font-color">*</div>
             </MBtnFont>
             <ModalBtn
               $isGet={!sMajor}
               type="seniorInfo"
-              btnText={sMajor ? sMajor : '학과를 선택해주세요.'}
+              btnText={sMajor ? sMajor : SENIOR_MAJOR.majorPlaceholder}
               modalHandler={modalHandler}
               onClick={() => {
                 setModalType('major');

--- a/src/app/signup/select/page.tsx
+++ b/src/app/signup/select/page.tsx
@@ -39,7 +39,7 @@ function SelectPage() {
             iconAlt="senior-icon"
             iconSrc={senior.src}
             iconText="선배 아이콘"
-            typeDesc={`멘토링을 받는`}
+            typeDesc={`멘토링을 하는`}
             typeDescColor={`대학원생 선배`}
             typeDescS={`회원가입`}
             userType="senior"

--- a/src/app/signup/select/page.tsx
+++ b/src/app/signup/select/page.tsx
@@ -7,6 +7,9 @@ import styled from 'styled-components';
 import junior from '../../../../public/junior.png';
 import senior from '../../../../public/senior.png';
 import GoogleAnalytics from '@/components/GA/GA';
+import { SIGNUP_COMMON } from '@/constants/signup/common';
+import { JUNIOR_SELECT } from '@/constants/signup/junior';
+import { SENIOR_SELECT } from '@/constants/signup/senior';
 function SelectPage() {
   const router = useRouter();
   const currentPath = usePathname();
@@ -20,27 +23,28 @@ function SelectPage() {
         <BackHeader headerText="회원가입" kind="home" />
       </div>
       <div style={{ margin: '1.6rem 1rem' }}>
-        <h3>회원 유형 선택</h3>
+        <h3>{SIGNUP_COMMON.selectTitle}</h3>
         <SignUpFont>
-          가입하시려는 회원의 유형을 선택해주세요. <br />
-          한쪽을 선택해도, 이후 마이페이지에서 전환 가능해요.
+          {SIGNUP_COMMON.selectDesc}
+          <br />
+          {SIGNUP_COMMON.convertDesc}
         </SignUpFont>
         <TypeBtnWrapper>
           <TypeBtn
             iconAlt="junior-icon"
             iconSrc={junior.src}
-            iconText="후배 아이콘"
-            typeDesc={`멘토링을 받는`}
-            typeDescColor={`대학생 후배`}
+            iconText={JUNIOR_SELECT.iconText}
+            typeDesc={JUNIOR_SELECT.typeDesc}
+            typeDescColor={JUNIOR_SELECT.userType}
             typeDescS={`회원가입`}
             userType="junior"
           />
           <TypeBtn
             iconAlt="senior-icon"
             iconSrc={senior.src}
-            iconText="선배 아이콘"
-            typeDesc={`멘토링을 하는`}
-            typeDescColor={`대학원생 선배`}
+            iconText={SENIOR_SELECT.iconText}
+            typeDesc={SENIOR_SELECT.typeDesc}
+            typeDescColor={SENIOR_SELECT.userType}
             typeDescS={`회원가입`}
             userType="senior"
           />

--- a/src/components/Button/SignUpBtn/SignUpBtn.tsx
+++ b/src/components/Button/SignUpBtn/SignUpBtn.tsx
@@ -141,7 +141,7 @@ function SignUpBtn() {
 
   return (
     <>
-      {schoolCharCount && fieldCharCount ? (
+      {(matchingReceive ? schoolCharCount && fieldCharCount : true) ? (
         <>
           <SignUpBtnContainer onClick={handleSignUp}>
             가입완료 하기

--- a/src/constants/signup/common.ts
+++ b/src/constants/signup/common.ts
@@ -1,0 +1,5 @@
+export const SIGNUP_COMMON = {
+  selectTitle: '회원 유형 선택',
+  selectDesc: '가입하시려는 회원의 유형을 선택해주세요.',
+  convertDesc: '한쪽을 선택해도, 이후 마이페이지에서 전환 가능해요.',
+};

--- a/src/constants/signup/junior.ts
+++ b/src/constants/signup/junior.ts
@@ -1,0 +1,5 @@
+export const JUNIOR_SELECT = {
+  iconText: '후배 아이콘',
+  typeDesc: '멘토링을 받는',
+  userType: '대학생 후배',
+};

--- a/src/constants/signup/junior.ts
+++ b/src/constants/signup/junior.ts
@@ -3,3 +3,14 @@ export const JUNIOR_SELECT = {
   typeDesc: '멘토링을 받는',
   userType: '대학생 후배',
 };
+
+export const JUNIOR_MATCHING = {
+  matchingTitle: '김선배가 딱 맞는 선배를 찾아드려요',
+  matchingDescFir: '찾고 있는 대학원 선배에 대해 알려주시면',
+  matchingDescSec: '김선배가 딱 맞는 선배가 있을 때 알림톡을 드려요!',
+  desiredSchoolTitle: '희망 대학원/학과',
+  desiredSchoolPlaceholder: `예시)연세대학원/컴퓨터과학과\n카이스트 대학원/생명화학공학과`,
+  desiredFieldTitle: '희망 연구분야/교수님',
+  desiredFieldPlaceholder: `예시)나노 소재/홍길동 교수님\n반도체 소자/아무개 교수님`,
+  matchingReceiveText: '(선택) 나에게 맞는 선배를 알림톡으로 받아볼래요!',
+};

--- a/src/constants/signup/senior.ts
+++ b/src/constants/signup/senior.ts
@@ -1,3 +1,9 @@
+export const SENIOR_SELECT = {
+  iconText: '선배 아이콘',
+  typeDesc: '멘토링을 하는',
+  userType: '대학원생 선배',
+};
+
 export const SENIOR_MAJOR = {
   seniorInfoTitle: '선배 정보를 입력해주세요.',
   seniorInfoUsage: '입력한 정보는 멘토링 매칭에 이용됩니다.',

--- a/src/constants/signup/senior.ts
+++ b/src/constants/signup/senior.ts
@@ -1,0 +1,25 @@
+export const SENIOR_MAJOR = {
+  seniorInfoTitle: '선배 정보를 입력해주세요.',
+  seniorInfoUsage: '입력한 정보는 멘토링 매칭에 이용됩니다.',
+  graduateSchoolTitle: '대학원 정보를 알려주세요.',
+  graduateSchool: '대학원',
+  graduateSchoolPlaceholder: '대학원을 선택해주세요.',
+  major: '학과',
+  majorPlaceholder: '학과를 선택해주세요.',
+};
+
+export const SENIOR_LAB = {
+  labTitle: '연구실 정보를 알려주세요.',
+  professor: '지도교수님',
+  professorPlaceholder: `'교수님' 글자를 제외하고 "성함"만 입력해주세요.`,
+  lab: '연구실명',
+  labPlaceholder: '연구실 이름을 입력해주세요.',
+};
+
+export const SENIOR_FIELD = {
+  fieldTitle: '소속 중인 연구실에 대해 알려주세요.',
+  field: '연구분야',
+  fieldPlaceholder: '선택된 연구분야가 없습니다.',
+  keyword: '연구주제',
+  keywordPlaceholder: '선택된 연구주제가 없습니다.',
+};


### PR DESCRIPTION
## 🦝 PR 요약
- 지도교수 입력 placeholder 수정
- 회원가입 파트 전체 상수화
- 무한 스크롤 버그 일부 수정
- 후배 회원가입 matching-info 오류 수정

## ✨ PR 상세 내용
- 선배 회원가입 지도교수 입력 placeholder "'교수님' 제외하고 글자를 제외하고 "성함"만 입력해주세요."로 변경
- 선후배 회원가입 파트 전체적으로 상수화 진행함
- 무한스크롤 버그 touchmove 이벤트 등록되어 있는 것 때문에 2번씩 호출되는 것 같아서 수정했습니다 (원준님이 보고해주신 버그는 아직 픽스 안 됐습니다 ㅠ_ㅠ)
- 후배 회원가입 matching-info에서 매칭 동의 안 하면 필드 안 채워도 가입할 수 있게 변경
- 선배 선택 "멘토링을 받는"으로 되어 있었던 것 "멘토링을 하는"으로 변경했습니다

## 🚨 주의 사항

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/677ff140-05fd-494c-b498-b9d131689ad8)

화면이 바뀐 부분은 여기밖에 없는 것 같네용

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
