### PR TITLE
RAC-421 refactor: 멘토링 소개 부분 react-hook-form ,yup으로 유효성 검사 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@hookform/resolvers": "^3.9.0",
     "@mui/material": "^5.14.18",
     "@mui/styled-engine-sc": "^6.0.0-alpha.6",
     "@tanstack/react-query": "4.36.1",
@@ -33,7 +34,8 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.52.2",
     "styled-components": "6.1.0",
-    "swiper": "11.0.5"
+    "swiper": "11.0.5",
+    "yup": "^1.4.0"
   },
   "devDependencies": {
     "@swc-jotai/react-refresh": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-calendar": "^4.7.0",
     "react-cookie": "6.1.1",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.52.2",
     "styled-components": "6.1.0",
     "swiper": "11.0.5"
   },

--- a/src/app/add-profile/page.tsx
+++ b/src/app/add-profile/page.tsx
@@ -44,7 +44,7 @@ function AddProfilePage() {
       multiIntro,
       recommended,
     },
-    mode: 'onBlur',
+    mode: 'onChange',
   });
 
   useEffect(() => {
@@ -55,7 +55,9 @@ function AddProfilePage() {
     'senior-best-case-portal',
   );
   const hasErrors =
-    errors.multiIntro || errors.recommended || errors.singleIntro;
+    errors.multiIntro?.message ||
+    errors.recommended?.message ||
+    errors.singleIntro?.message;
 
   const handleClick = async () => {
     if (hasErrors) {
@@ -138,13 +140,12 @@ function AddProfilePage() {
         >
           이전
         </PrevBtn>
-        {!hasErrors ? (
-          <NextAddBtnSet onClick={handleSubmit(handleClick)}>
-            다음
-          </NextAddBtnSet>
-        ) : (
-          <NextAddBtn onClick={handleSubmit(handleClick)}>다음</NextAddBtn>
-        )}
+        <NextAddBtnSet
+          onClick={handleSubmit(handleClick)}
+          hasError={hasErrors?.length > 0}
+        >
+          다음
+        </NextAddBtnSet>
       </div>
       {modal && portalElement
         ? createPortal(
@@ -209,27 +210,7 @@ const ShowProfBtn = styled.button`
   border: none;
   cursor: pointer;
 `;
-const NextAddBtn = styled.button`
-  display: flex;
-  width: 57%;
-  padding: 1rem 0rem;
-  justify-content: center;
-  align-items: center;
-  gap: 0.625rem;
-  margin-left: 0.4rem;
-  border-radius: 0.75rem;
-  background: #dee2e6;
-  border: none;
-  color: #fff;
-  text-align: center;
-  font-family: Pretendard;
-  font-size: 1.125rem;
-  font-style: normal;
-  font-weight: 700;
-  line-height: normal;
-  cursor: pointer;
-`;
-const NextAddBtnSet = styled.button`
+const NextAddBtnSet = styled.button<{ hasError: boolean | undefined }>`
   display: flex;
   width: 57%;
   padding: 1rem 0rem;
@@ -238,7 +219,7 @@ const NextAddBtnSet = styled.button`
   gap: 0.625rem;
   margin-left: 0.4rem;
   border: none;
-  background: #2fc4b2;
+  background: ${({ hasError }) => (hasError ? '#dee2e6;' : '#2fc4b2')};
   border-radius: 0.75rem;
   color: #fff;
   text-align: center;

--- a/src/app/add-profile/page.tsx
+++ b/src/app/add-profile/page.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useEffect } from 'react';
 import ProgressBar from '@/components/Bar/ProgressBar';
 
 import { addProfileSchema } from '@/app/add-profile/schema';
 import BackHeader from '@/components/Header/BackHeader';
 
+import { FieldError, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import FullModal from '@/components/Modal/FullModal';
 import ProfileForm from '@/components/SingleForm/ProfileForm';
 import SingleValidator from '@/components/Validator/SingleValidator';
-import { FieldError, useForm } from 'react-hook-form';
+
 import {
   PROFILE_DIRECTION,
   PROFILE_PLACEHOLDER,
@@ -47,9 +47,6 @@ function AddProfilePage() {
     mode: 'onChange',
   });
 
-  useEffect(() => {
-    trigger();
-  }, []);
   const router = useRouter();
   const { modal, modalHandler, portalElement } = useModal(
     'senior-best-case-portal',

--- a/src/app/add-profile/page.tsx
+++ b/src/app/add-profile/page.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import FullModal from '@/components/Modal/FullModal';
 import ProfileForm from '@/components/SingleForm/ProfileForm';
 import SingleValidator from '@/components/Validator/SingleValidator';
-import { useForm } from 'react-hook-form';
+import { FieldError, useForm } from 'react-hook-form';
 import {
   PROFILE_DIRECTION,
   PROFILE_PLACEHOLDER,
@@ -55,9 +55,7 @@ function AddProfilePage() {
     'senior-best-case-portal',
   );
   const hasErrors =
-    errors.multiIntro?.message ||
-    errors.recommended?.message ||
-    errors.singleIntro?.message;
+    errors.multiIntro || errors.recommended || errors.singleIntro;
 
   const handleClick = async () => {
     if (hasErrors) {
@@ -140,10 +138,7 @@ function AddProfilePage() {
         >
           이전
         </PrevBtn>
-        <NextAddBtnSet
-          onClick={handleSubmit(handleClick)}
-          hasError={hasErrors?.length > 0}
-        >
+        <NextAddBtnSet onClick={handleSubmit(handleClick)} hasError={hasErrors}>
           다음
         </NextAddBtnSet>
       </div>
@@ -210,7 +205,7 @@ const ShowProfBtn = styled.button`
   border: none;
   cursor: pointer;
 `;
-const NextAddBtnSet = styled.button<{ hasError: boolean | undefined }>`
+const NextAddBtnSet = styled.button<{ hasError: FieldError | undefined }>`
   display: flex;
   width: 57%;
   padding: 1rem 0rem;

--- a/src/app/add-profile/schema.ts
+++ b/src/app/add-profile/schema.ts
@@ -1,0 +1,35 @@
+import { object, string, InferType, ValidationError } from 'yup';
+
+const VALIDATE_MSG = {
+  no_single_intro: '한줄소개를 입력해주세요',
+  no_multi_intro: '자기소개를 입력해주세요',
+  no_recommended: '추천대상을 입력해주세요',
+  min_single_intro_length: '최소 10자 이상 입력해 주세요.',
+  min_multi_intro_length: '자기소개를 50자 이상 작성해주세요',
+  min_recommended_length: '추천대상을 50자 이상 작성해주세요',
+};
+
+export const addProfileSchema = object({
+  singleIntro: string()
+    .required(VALIDATE_MSG.no_single_intro)
+    .min(10, VALIDATE_MSG.min_single_intro_length),
+  multiIntro: string()
+    .required(VALIDATE_MSG.no_multi_intro)
+    .min(50, VALIDATE_MSG.min_multi_intro_length),
+  recommended: string()
+    .required(VALIDATE_MSG.no_recommended)
+    .min(50, VALIDATE_MSG.min_recommended_length),
+});
+
+type AddProfile = InferType<typeof addProfileSchema>;
+
+export const validateAddProfileError = async (data: AddProfile) => {
+  try {
+    await addProfileSchema.validate(data);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      console.log(e);
+      throw e;
+    }
+  }
+};

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import React from 'react';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';

--- a/src/components/SingleForm/ProfileForm/ProfileForm.tsx
+++ b/src/components/SingleForm/ProfileForm/ProfileForm.tsx
@@ -1,60 +1,69 @@
+import React, { forwardRef, useEffect, useState } from 'react';
 import { ProfileFormProps } from '@/types/form/profileForm';
 import {
   ProfileFormContainer,
   ProfileTitleContainer,
 } from './ProfileForm.styled';
-import { useEffect, useState } from 'react';
-function ProfileForm(props: ProfileFormProps) {
-  const [charCount, setCharCount] = useState(0);
 
-  useEffect(() => {
-    if (props.loadStr) {
-      const targetForm = document.querySelector(
-        `.profile-form-${props.formType}`,
-      ) as HTMLInputElement | HTMLTextAreaElement;
-      targetForm.value = props.loadStr;
-      setCharCount(props.loadStr.length);
-      return;
-    }
-  }, [props.loadStr]);
+const ProfileForm = forwardRef<HTMLTextAreaElement, ProfileFormProps>(
+  (props, ref) => {
+    const [charCount, setCharCount] = useState(0);
 
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    if (props.maxLength && e.currentTarget.value.length > props.maxLength) {
-      e.currentTarget.value = e.currentTarget.value.slice(0, props.maxLength);
-    }
-    props.changeHandler(e.currentTarget.value);
-    setCharCount(e.currentTarget.value.length);
-  };
+    useEffect(() => {
+      if (props.loadStr) {
+        const targetForm = document.querySelector(
+          `.profile-form-${props.formType}`,
+        ) as HTMLInputElement | HTMLTextAreaElement;
+        if (targetForm) {
+          targetForm.value = props.loadStr;
+        }
+        setCharCount(props.loadStr.length);
+      }
+    }, [props.loadStr]);
 
-  return (
-    <ProfileFormContainer $flag={props.flag}>
-      <ProfileTitleContainer>
-        <div>{props.title}</div>
-        <div id="char-count">
-          {charCount} / {props.maxLength || 0} 자
-        </div>
-      </ProfileTitleContainer>
-      {props.lineType == 'single' && (
-        <textarea
-          id="single-profile-form"
-          className={`profile-form-${props.formType}`}
-          placeholder={props.placeholder}
-          onChange={(e) => handleChange(e)}
-        />
-      )}
-      {props.lineType == 'multi' && (
-        <textarea
-          name="profile-form"
-          id="multi-profile-form"
-          className={`profile-form-${props.formType}`}
-          placeholder={props.placeholder}
-          onChange={(e) => handleChange(e)}
-        ></textarea>
-      )}
-    </ProfileFormContainer>
-  );
-}
+    const handleChange = (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+      if (props.maxLength && e.currentTarget.value.length > props.maxLength) {
+        e.currentTarget.value = e.currentTarget.value.slice(0, props.maxLength);
+      }
+
+      if (props.changeHandler) {
+        props.changeHandler(e.currentTarget.value);
+      }
+
+      setCharCount(e.currentTarget.value.length);
+    };
+
+    return (
+      <ProfileFormContainer $flag={props.flag}>
+        <ProfileTitleContainer>
+          <div>{props.title}</div>
+          <div id="char-count">
+            {charCount} / {props.maxLength || 0} 자
+          </div>
+        </ProfileTitleContainer>
+        {props.lineType === 'single' && (
+          <textarea
+            id="single-profile-form"
+            className={`profile-form-${props.formType}`}
+            placeholder={props.placeholder}
+            {...props?.register}
+            onChange={handleChange}
+          />
+        )}
+        {props.lineType === 'multi' && (
+          <textarea
+            id="multi-profile-form"
+            className={`profile-form-${props.formType}`}
+            placeholder={props.placeholder}
+            {...props?.register}
+            onChange={handleChange}
+          ></textarea>
+        )}
+      </ProfileFormContainer>
+    );
+  },
+);
 
 export default ProfileForm;

--- a/src/components/SingleForm/ProfileForm/ProfileForm.tsx
+++ b/src/components/SingleForm/ProfileForm/ProfileForm.tsx
@@ -6,7 +6,7 @@ import {
 } from './ProfileForm.styled';
 
 const ProfileForm = forwardRef<HTMLTextAreaElement, ProfileFormProps>(
-  (props, ref) => {
+  (props, _ref) => {
     const [charCount, setCharCount] = useState(0);
 
     useEffect(() => {
@@ -49,7 +49,10 @@ const ProfileForm = forwardRef<HTMLTextAreaElement, ProfileFormProps>(
             className={`profile-form-${props.formType}`}
             placeholder={props.placeholder}
             {...props?.register}
-            onChange={handleChange}
+            onChange={(e) => {
+              props.register?.onChange(e);
+              handleChange(e);
+            }}
           />
         )}
         {props.lineType === 'multi' && (
@@ -58,7 +61,10 @@ const ProfileForm = forwardRef<HTMLTextAreaElement, ProfileFormProps>(
             className={`profile-form-${props.formType}`}
             placeholder={props.placeholder}
             {...props?.register}
-            onChange={handleChange}
+            onChange={(e) => {
+              props.register?.onChange(e);
+              handleChange(e);
+            }}
           ></textarea>
         )}
       </ProfileFormContainer>

--- a/src/types/form/profileForm.tsx
+++ b/src/types/form/profileForm.tsx
@@ -1,6 +1,7 @@
 import { PrimitiveAtom, SetStateAction } from 'jotai';
-import { ComponentPropsWithRef } from 'react';
-import { RegisterOptions, UseFormRegisterReturn } from 'react-hook-form';
+import { ChangeEvent } from 'react';
+
+import { UseFormRegisterReturn } from 'react-hook-form';
 
 type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
 
@@ -8,7 +9,7 @@ type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
 export type lineType = 'single' | 'multi';
 export type profileFormType = 'singleIntro' | 'multiIntro' | 'recommendedFor';
 
-export interface ProfileFormProps extends ComponentPropsWithRef<'input'> {
+export interface ProfileFormProps {
   flag: boolean;
   lineType: lineType;
   title: string;
@@ -16,5 +17,7 @@ export interface ProfileFormProps extends ComponentPropsWithRef<'input'> {
   loadStr: string;
   formType: profileFormType;
   changeHandler?: SetAtom<[SetStateAction<string>], void>;
-  register?:UseFormRegisterReturn
+  register?: UseFormRegisterReturn;
+  placeholder?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }

--- a/src/types/form/profileForm.tsx
+++ b/src/types/form/profileForm.tsx
@@ -1,4 +1,6 @@
 import { PrimitiveAtom, SetStateAction } from 'jotai';
+import { ComponentPropsWithRef } from 'react';
+import { RegisterOptions, UseFormRegisterReturn } from 'react-hook-form';
 
 type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
 
@@ -6,13 +8,13 @@ type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
 export type lineType = 'single' | 'multi';
 export type profileFormType = 'singleIntro' | 'multiIntro' | 'recommendedFor';
 
-export interface ProfileFormProps {
+export interface ProfileFormProps extends ComponentPropsWithRef<'input'> {
   flag: boolean;
   lineType: lineType;
   title: string;
   maxLength?: number; // lineType이 'multi'인 경우에만 들어옴
-  placeholder: string;
   loadStr: string;
   formType: profileFormType;
-  changeHandler: SetAtom<[SetStateAction<string>], void>;
+  changeHandler?: SetAtom<[SetStateAction<string>], void>;
+  register?:UseFormRegisterReturn
 }


### PR DESCRIPTION
## 🦝 PR 요약
- 멘토링 소개 유효성 검증 부분 react-hook-form과 yup으로 변경

## ✨ PR 상세 내용
- 멘토링 소개 부분의 폼 검증을 hookform을 써서 변경하였습니다.
- 한줄소개, 자기소개, 추천대상에 대해 스키마를 만들고 검증을 하게 해주었습니다.

## 🚨 주의 사항
- 의존성 부분에 훅폼과, yup을 추가로 설치하였습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/76291506-8b06-4a63-b9a0-4f37ef26a76b




## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
