### PR TITLE
RAC-428 feat: 탈퇴 후 재활성화 로직 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jotai": "^2.5.1",
     "jquery": "^3.7.1",
     "next": "13.5.4",
+    "overlay-kit": "^1.4.1",
     "prettier": "3.0.3",
     "react": "18.2.0",
     "react-calendar": "^4.7.0",

--- a/src/api/auth/login/kakaoAuthFetch.tsx
+++ b/src/api/auth/login/kakaoAuthFetch.tsx
@@ -1,5 +1,6 @@
 import instance from '@/api/api';
 import { ResponseModel } from '@/api/model';
+import axios from 'axios';
 
 interface KakaoAuthFetchResponse extends ResponseModel {
   data: {
@@ -15,7 +16,7 @@ interface KakaoAuthFetchResponse extends ResponseModel {
 }
 
 export const kakaoAuthFetch = async ({ code }: { code: string }) => {
-  return await instance.post<KakaoAuthFetchResponse>(
+  return await axios.post<KakaoAuthFetchResponse>(
     window.location.hostname.includes('localhost')
       ? `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/dev/login/KAKAO`
       : `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/login/KAKAO`,

--- a/src/api/auth/login/kakaoAuthFetch.tsx
+++ b/src/api/auth/login/kakaoAuthFetch.tsx
@@ -2,7 +2,7 @@ import instance from '@/api/api';
 import { ResponseModel } from '@/api/model';
 import axios from 'axios';
 
-interface KakaoAuthFetchResponse extends ResponseModel {
+export interface KakaoAuthFetchResponse extends ResponseModel {
   data: {
     accessToken: string;
     accessExpiration: number;

--- a/src/api/auth/login/kakaoAuthFetch.tsx
+++ b/src/api/auth/login/kakaoAuthFetch.tsx
@@ -1,0 +1,26 @@
+import instance from '@/api/api';
+import { ResponseModel } from '@/api/model';
+
+interface KakaoAuthFetchResponse extends ResponseModel {
+  data: {
+    accessToken: string;
+    accessExpiration: number;
+    refreshToken: string;
+    role: 'USER' | 'ADMIN' | 'SENIOR';
+    isTutorial: boolean;
+    refreshExpiration: number;
+    socialId: string;
+    isDelete: boolean;
+  };
+}
+
+export const kakaoAuthFetch = async ({ code }: { code: string }) => {
+  return await instance.post<KakaoAuthFetchResponse>(
+    window.location.hostname.includes('localhost')
+      ? `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/dev/login/KAKAO`
+      : `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/login/KAKAO`,
+    {
+      code: code,
+    },
+  );
+};

--- a/src/api/auth/rejoin/rejoinPatchFetch.ts
+++ b/src/api/auth/rejoin/rejoinPatchFetch.ts
@@ -1,0 +1,17 @@
+import instance from '@/api/api';
+import { KakaoAuthFetchResponse } from '@/api/auth/login/kakaoAuthFetch';
+
+interface RejoinFetchRequest {
+  socialId: string;
+  rejoin: boolean;
+}
+
+export const rejoinPatchFetch = async ({
+  socialId,
+  rejoin,
+}: RejoinFetchRequest) => {
+  return await instance.patch<KakaoAuthFetchResponse>('/auth/rejoin/KAKAO', {
+    socialId,
+    rejoin,
+  });
+};

--- a/src/api/model.ts
+++ b/src/api/model.ts
@@ -1,0 +1,89 @@
+export interface ResponseModel {
+  code: SuccessStatusType | ErrorStatusType;
+  message: string;
+}
+
+/**
+ * 성공 코드
+ * @see https://www.notion.so/5375748c8c4147ed85f0980d7fc06bcb
+ */
+export type SuccessStatusType =
+  | 'UR200'
+  | 'UR201'
+  | 'UR202'
+  | 'UR203'
+  | 'SNR200'
+  | 'SNR201'
+  | 'SNR202'
+  | 'SNR203'
+  | 'MT200'
+  | 'MT201'
+  | 'MT202'
+  | 'MT203'
+  | 'PM200'
+  | 'PM201'
+  | 'PM202'
+  | 'PM203'
+  | 'RV200'
+  | 'RV201'
+  | 'RV202'
+  | 'RV203'
+  | 'AU200'
+  | 'AU201'
+  | 'AU202'
+  | 'AU203'
+  | 'AU204'
+  | 'AU205'
+  | 'ACT200'
+  | 'ACT201'
+  | 'ACT202'
+  | 'ACT203'
+  | 'IMG200'
+  | 'IMG201'
+  | 'IMG202'
+  | 'IMG203'
+  | 'SLR200'
+  | 'SLR201'
+  | 'SLR202'
+  | 'SLR203'
+  | 'ADM200'
+  | 'ADM201';
+
+/**
+ * 에러 코드
+ * @see https://www.notion.so/240430-c0e2fd72f06b45028e8e463d6faa32f9
+ */
+export type ErrorStatusType =
+  | 'EX1000'
+  | 'EX900'
+  | 'EX901'
+  | 'EX902'
+  | 'EX903'
+  | 'EX904'
+  | 'EX800'
+  | 'EX801'
+  | 'EX802'
+  | 'EX700'
+  | 'EX701'
+  | 'EX702'
+  | 'EX703'
+  | 'EX704'
+  | 'EX705'
+  | 'EX706'
+  | 'EX600'
+  | 'EX601'
+  | 'EX500'
+  | 'EX501'
+  | 'EX400'
+  | 'EX401'
+  | 'EX402'
+  | 'EX403'
+  | 'EX404'
+  | 'EX405'
+  | 'EX406'
+  | 'EX300'
+  | 'EX301'
+  | 'EX302'
+  | 'EX200'
+  | 'EX201'
+  | 'EX202';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import StyledComponentsRegistry from '@/lib/registry';
 import GTMAnalytics from '@/components/GA/GTM';
 import GoogleAnalytics from '@/components/GA/GA';
 import { SERVICE_METADATA } from '@/constants/meta/metaData';
-
+import OverlayKitProvider from '@/lib/overlay';
 export const metadata: Metadata = {
   title: SERVICE_METADATA.title,
   description: SERVICE_METADATA.description,
@@ -27,32 +27,34 @@ export default function RootLayout({
         {process.env.NEXT_PUBLIC_GA4_ID ? <GoogleAnalytics /> : <></>}
         <Providers>
           <StyledComponentsRegistry>
-            {children}
-            <div id="senior-info-portal"></div>
-            <div id="junior-mentoring-detail"></div>
-            <div id="junior-mentoring-cancel"></div>
-            <div id="senior-profile-portal"></div>
-            <div id="login-request-portal"></div>
-            <div id="senior-best-case-portal"></div>
-            <div id="login-request-full-portal"></div>
-            <div id="search-portal"></div>
-            <div id="senior-my-profile-portal"></div>
-            <div id="senior-request-portal"></div>
-            <div id="junior-request-portal"></div>
-            <div id="profile-modify-portal"></div>
-            <div id="senior-mentoring-detail"></div>
-            <div id="senior-mentoring-cancel"></div>
-            <div id="senior-mentoring-accept"></div>
-            <div id="senior-info-modify-portal"></div>
-            <div id="senior-mentoring-time-portal"></div>
-            <div id="senior-profile-not-registered"></div>
-            <div id="select-date-calendar"></div>
-            <div id="suggest-mypage-portal"></div>
-            <div id="senior-auth-portal"></div>
-            <div id="mentoring-login-portal"></div>
-            <div id="change-junior-portal"></div>
-            <div id=" mentoring-cancel-success"></div>
-            <div id="pay-amount-portal"></div>
+            <OverlayKitProvider>
+              {children}
+              <div id="senior-info-portal"></div>
+              <div id="junior-mentoring-detail"></div>
+              <div id="junior-mentoring-cancel"></div>
+              <div id="senior-profile-portal"></div>
+              <div id="login-request-portal"></div>
+              <div id="senior-best-case-portal"></div>
+              <div id="login-request-full-portal"></div>
+              <div id="search-portal"></div>
+              <div id="senior-my-profile-portal"></div>
+              <div id="senior-request-portal"></div>
+              <div id="junior-request-portal"></div>
+              <div id="profile-modify-portal"></div>
+              <div id="senior-mentoring-detail"></div>
+              <div id="senior-mentoring-cancel"></div>
+              <div id="senior-mentoring-accept"></div>
+              <div id="senior-info-modify-portal"></div>
+              <div id="senior-mentoring-time-portal"></div>
+              <div id="senior-profile-not-registered"></div>
+              <div id="select-date-calendar"></div>
+              <div id="suggest-mypage-portal"></div>
+              <div id="senior-auth-portal"></div>
+              <div id="mentoring-login-portal"></div>
+              <div id="change-junior-portal"></div>
+              <div id=" mentoring-cancel-success"></div>
+              <div id="pay-amount-portal"></div>
+            </OverlayKitProvider>
           </StyledComponentsRegistry>
         </Providers>
       </body>

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -57,14 +57,23 @@ function KakaoPage() {
         setSocialId(socialId);
         localStorage.setItem('socialId', socialId);
         if (isDelete) {
-          overlay.open(({}) => {
-            return (
-              <FullModal modalType="account-reactive" modalHandler={() => {}} />
-            );
-          });
-        }
+          const agreeActivateAccount = await overlay.openAsync<boolean>(
+            ({ isOpen, close }) => {
+              return (
+                <div>
+                  <button onClick={() => close(true)}>네</button>
+                  <button onClick={() => close(false)}>아니오</button>
+                </div>
+              );
+            },
+          );
 
-        alert(kakaoAuthFetchRes.data.isDelete);
+          if (agreeActivateAccount) {
+            alert('동의');
+          } else {
+            alert('비동의');
+          }
+        }
       } catch (error) {
         console.error(error);
       }

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -1,107 +1,12 @@
 'use client';
 
-import React, { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import useAuth from '@/hooks/useAuth';
-import { useSetAtom } from 'jotai';
-import { socialIdAtom, isTutorialFinished } from '@/stores/signup';
-import Spinner from '@/components/Spinner';
+import React from 'react';
 import styled from 'styled-components';
-import { kakaoAuthFetch } from '@/api/auth/login/kakaoAuthFetch';
-import { overlay } from 'overlay-kit';
-import FullModal from '@/components/Modal/FullModal';
-import { rejoinPatchFetch } from '@/api/auth/rejoin/rejoinPatchFetch';
+import Spinner from '@/components/Spinner';
+import useKakaoLogin from '@/hooks/useKakaoLogin';
 
 function KakaoPage() {
-  const setSocialId = useSetAtom(socialIdAtom);
-  const setTutorialFinished = useSetAtom(isTutorialFinished);
-  const router = useRouter();
-  const { setAccessToken, setRefreshToken, setUserType } = useAuth();
-
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const code = urlParams.get('code');
-
-    const fetchKakaoData = async () => {
-      try {
-        const { data: kakaoAuthFetchRes } = await kakaoAuthFetch({
-          code: code ?? '',
-        });
-
-        const {
-          accessExpiration,
-          accessToken,
-          refreshToken,
-          role,
-          isTutorial,
-          refreshExpiration,
-          socialId,
-          isDelete,
-        } = kakaoAuthFetchRes.data;
-
-        if (kakaoAuthFetchRes.code === 'AU204') {
-          setAccessToken({
-            token: accessToken,
-            expires: accessExpiration,
-          });
-          setRefreshToken({
-            token: refreshToken,
-            expires: refreshExpiration,
-          });
-          setUserType(role);
-          setTutorialFinished(isTutorial);
-          router.replace('/');
-          return;
-          //재가입 여부 입력 받을 때까지 지연
-        }
-
-        setSocialId(socialId);
-        localStorage.setItem('socialId', socialId);
-        if (isDelete) {
-          const agreeActivateAccount = await overlay.openAsync<boolean>(
-            ({ isOpen, close }) => {
-              return (
-                <div>
-                  <button
-                    onClick={async () =>
-                      await rejoinPatchFetch({
-                        socialId,
-                        rejoin: true,
-                      }).then((res) => {
-                        setAccessToken({
-                          token: accessToken,
-                          expires: accessExpiration,
-                        });
-                        setRefreshToken({
-                          token: refreshToken,
-                          expires: refreshExpiration,
-                        });
-                        setUserType(role);
-                        setTutorialFinished(isTutorial);
-                      })
-                    }
-                  >
-                    네
-                  </button>
-                  <button onClick={() => close(false)}>아니오</button>
-                </div>
-              );
-            },
-          );
-
-          if (agreeActivateAccount) {
-            alert('동의');
-          } else {
-            alert('비동의');
-          }
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
-    fetchKakaoData();
-  }, []);
+  useKakaoLogin();
 
   return (
     <KakaoLoginPageContainer>

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { kakaoAuthFetch } from '@/api/auth/login/kakaoAuthFetch';
 import { overlay } from 'overlay-kit';
 import FullModal from '@/components/Modal/FullModal';
+import { rejoinPatchFetch } from '@/api/auth/rejoin/rejoinPatchFetch';
 
 function KakaoPage() {
   const setSocialId = useSetAtom(socialIdAtom);
@@ -61,7 +62,27 @@ function KakaoPage() {
             ({ isOpen, close }) => {
               return (
                 <div>
-                  <button onClick={() => close(true)}>네</button>
+                  <button
+                    onClick={async () =>
+                      await rejoinPatchFetch({
+                        socialId,
+                        rejoin: true,
+                      }).then((res) => {
+                        setAccessToken({
+                          token: accessToken,
+                          expires: accessExpiration,
+                        });
+                        setRefreshToken({
+                          token: refreshToken,
+                          expires: refreshExpiration,
+                        });
+                        setUserType(role);
+                        setTutorialFinished(isTutorial);
+                      })
+                    }
+                  >
+                    네
+                  </button>
                   <button onClick={() => close(false)}>아니오</button>
                 </div>
               );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,20 +7,19 @@ import SeniorProfile from '../components/SeniorProfile/SeniorProfile';
 import FieldTapBar from '../components/Bar/FieldTapBar/FieldTapBar';
 import UnivTapBar from '../components/Bar/UnivTapBar/UnivTapBar';
 import SwiperComponent from '../components/Swiper/Swiper';
-import { createPortal } from 'react-dom';
 import useModal from '../hooks/useModal';
 import DimmedModal from '../components/Modal/DimmedModal';
 import SearchModal from '../components/Modal/SearchModal';
 import { sfactiveTabAtom, suactiveTabAtom } from '../stores/tap';
 import axios from 'axios';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { isTutorialFinished } from '@/stores/signup';
-import { useTour } from '@reactour/tour';
+
 import LogoLayer from '@/components/LogoLayer/LogoLayer';
 import { listDataAtom, pageNumAtom } from '@/stores/home';
 import Footer from '@/components/Footer';
 
 import useTutorial from '@/hooks/useTutorial';
+import { overlay } from 'overlay-kit';
 
 export default function Home() {
   const { setCurrentPath } = usePrevPath();
@@ -84,15 +83,9 @@ export default function Home() {
     };
   }, [page]);
 
-  const { modal, modalHandler, portalElement } = useModal(
-    'login-request-portal',
-  );
+  const { modal, modalHandler } = useModal('');
 
-  const {
-    modal: searchModal,
-    modalHandler: searchModalHandler,
-    portalElement: searchPortalElement,
-  } = useModal('search-portal');
+  const { modal: searchModal, modalHandler: searchModalHandler } = useModal('');
 
   return (
     <HomeLayer>
@@ -121,17 +114,29 @@ export default function Home() {
       <MenuBarWrapper>
         <MenuBar modalHandler={modalHandler} />
       </MenuBarWrapper>
-      {modal && portalElement
-        ? createPortal(
-            <DimmedModal modalType="notuser" modalHandler={modalHandler} />,
-            portalElement,
-          )
+
+      {modal
+        ? overlay.open(({ unmount }) => {
+            return (
+              <DimmedModal
+                modalType="notuser"
+                modalHandler={() => {
+                  unmount();
+                }}
+              />
+            );
+          })
         : ''}
-      {searchModal && searchPortalElement
-        ? createPortal(
-            <SearchModal modalHandler={searchModalHandler} />,
-            searchPortalElement,
-          )
+      {searchModal
+        ? overlay.open(({ unmount }) => {
+            return (
+              <SearchModal
+                modalHandler={() => {
+                  unmount();
+                }}
+              />
+            );
+          })
         : ''}
     </HomeLayer>
   );

--- a/src/app/signout/(components)/signout-type-select/index.tsx
+++ b/src/app/signout/(components)/signout-type-select/index.tsx
@@ -56,7 +56,7 @@ export const SignOutInfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100vh;
+  height: 80vh;
 
   > h1 {
     font-size: 20px;

--- a/src/components/Content/AccountReactivation/AccountReactivation.tsx
+++ b/src/components/Content/AccountReactivation/AccountReactivation.tsx
@@ -1,5 +1,58 @@
-function AccountReactivation() {
-  return <div>asdsd</div>;
+import styled from 'styled-components';
+import NextBtn from '@/components/Button/NextBtn';
+
+interface AccountReactivationProps {
+  onActive?: () => void;
+  onNonActive?: () => void;
+}
+
+const Container = styled.div`
+  width: 100%;
+  height: 100vh; /* 전체 화면 높이에 맞춤 */
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+
+  h2 {
+    font-size: 24px;
+    margin-bottom: 15px;
+  }
+
+  div {
+    font-size: 16px;
+    width: 100%;
+    margin-bottom: 20px;
+  }
+
+  @media (max-width: 600px) {
+    h2 {
+      font-size: 20px;
+    }
+
+    div {
+      font-size: 14px;
+    }
+  }
+`;
+
+function AccountReactivation({
+  onActive,
+  onNonActive,
+}: AccountReactivationProps) {
+  return (
+    <Container>
+      <h2>계정을 재활성화 하시겠어요?</h2>
+      <div>
+        “재활성화 합니다.” 버튼을 클릭하시면 계정이 재활성화 되며 계정
+        비활성화가 중단됩니다.
+      </div>
+      <NextBtn kind="route" btnText="재활성화합니다." onClick={onActive} />
+      <NextBtn kind="route-non" btnText="아니오." onClick={onNonActive} />
+    </Container>
+  );
 }
 
 export default AccountReactivation;

--- a/src/components/Content/AccountReactivation/AccountReactivation.tsx
+++ b/src/components/Content/AccountReactivation/AccountReactivation.tsx
@@ -14,6 +14,7 @@ const Container = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
   flex-direction: column;
   text-align: center;
 

--- a/src/components/Content/AccountReactivation/AccountReactivation.tsx
+++ b/src/components/Content/AccountReactivation/AccountReactivation.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import NextBtn from '@/components/Button/NextBtn';
 
+import { BtnStyleNon } from '@/components/Button/NextBtn/NextBtn.styled';
 interface AccountReactivationProps {
   onActive?: () => void;
   onNonActive?: () => void;
@@ -50,7 +51,7 @@ function AccountReactivation({
         비활성화가 중단됩니다.
       </div>
       <NextBtn kind="route" btnText="재활성화합니다." onClick={onActive} />
-      <NextBtn kind="route-non" btnText="아니오." onClick={onNonActive} />
+      <BtnStyleNon onClick={onNonActive}>아니오.</BtnStyleNon>
     </Container>
   );
 }

--- a/src/components/Content/AccountReactivation/AccountReactivation.tsx
+++ b/src/components/Content/AccountReactivation/AccountReactivation.tsx
@@ -9,7 +9,7 @@ interface AccountReactivationProps {
 
 const Container = styled.div`
   width: 100%;
-  height: 100vh; /* 전체 화면 높이에 맞춤 */
+  height: 100vh;
   padding: 20px;
   display: flex;
   justify-content: center;

--- a/src/components/Content/AccountReactivation/AccountReactivation.tsx
+++ b/src/components/Content/AccountReactivation/AccountReactivation.tsx
@@ -1,0 +1,5 @@
+function AccountReactivation() {
+  return <div>asdsd</div>;
+}
+
+export default AccountReactivation;

--- a/src/components/Content/AccountReactivation/index.tsx
+++ b/src/components/Content/AccountReactivation/index.tsx
@@ -1,0 +1,3 @@
+import AccountReactivation from './AccountReactivation';
+
+export default AccountReactivation;

--- a/src/components/Modal/FullModal/FullModal.tsx
+++ b/src/components/Modal/FullModal/FullModal.tsx
@@ -18,6 +18,7 @@ function FullModal(props: FullModalProps) {
         {props.modalType == 'best-case' && (
           <MBestCaseContent modalHandler={props.modalHandler} />
         )}
+        {props.modalType === 'account-reactive' && <div>asd</div>}
         {props.modalType == 'login-request' && (
           <MyLoginRequest modalHandler={props.modalHandler} />
         )}

--- a/src/components/Modal/FullModal/FullModal.tsx
+++ b/src/components/Modal/FullModal/FullModal.tsx
@@ -11,6 +11,7 @@ import SmentoringSpec from '@/components/Mentoring/MentoringSpec/SmentoringSpec/
 import SelectCalendar from '@/components/Content/SelectCalendar';
 import { firAbleTimeAtom } from '@/stores/mentoring';
 import MentoringSpec from '@/components/Mentoring/MentoringSpec/JmentoringSpec';
+import AccountReactivation from '@/components/Content/AccountReactivation';
 function FullModal(props: FullModalProps) {
   return (
     <>
@@ -18,7 +19,12 @@ function FullModal(props: FullModalProps) {
         {props.modalType == 'best-case' && (
           <MBestCaseContent modalHandler={props.modalHandler} />
         )}
-        {props.modalType === 'account-reactive' && <div>asd</div>}
+        {props.modalType === 'account-reactive' && (
+          <AccountReactivation
+            onActive={props.modalHandler}
+            onNonActive={props.cancelModalHandler}
+          />
+        )}
         {props.modalType == 'login-request' && (
           <MyLoginRequest modalHandler={props.modalHandler} />
         )}

--- a/src/components/Modal/SearchModal/SearchModal.tsx
+++ b/src/components/Modal/SearchModal/SearchModal.tsx
@@ -8,6 +8,7 @@ export default function SearchModal(props: SearchModalProps) {
   const ModalClick = () => {
     props.modalHandler();
   };
+  console.log(props.modalHandler);
   return (
     <SearchModalBgBox onClick={ModalClick}>
       <SearchModalInput onClick={(e) => e.stopPropagation()}>

--- a/src/components/SingleForm/HomeSearchForm/HomeSearchForm.tsx
+++ b/src/components/SingleForm/HomeSearchForm/HomeSearchForm.tsx
@@ -17,8 +17,8 @@ function HomeSearchForm(props: SearchModalProps) {
 
   const keyPressDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      router.push(`/search-results?searchTerm=${searchTerm}`);
       props.modalHandler();
+      router.push(`/search-results?searchTerm=${searchTerm}`);
     }
   };
   return (

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import useAuth from '@/hooks/useAuth';
+import AccountReactivation from '@/components/Content/AccountReactivation';
 import { useSetAtom } from 'jotai';
 import { socialIdAtom, isTutorialFinished } from '@/stores/signup';
 import { overlay } from 'overlay-kit';
@@ -9,6 +10,7 @@ import {
   kakaoAuthFetch,
 } from '@/api/auth/login/kakaoAuthFetch';
 import { rejoinPatchFetch } from '@/api/auth/rejoin/rejoinPatchFetch';
+import FullModal from '@/components/Modal/FullModal';
 
 const useKakaoLogin = () => {
   const setSocialId = useSetAtom(socialIdAtom);
@@ -55,28 +57,21 @@ const useKakaoLogin = () => {
         if (isDelete) {
           const agreeActivateAccount = await overlay.openAsync<boolean>(
             ({ close, unmount }) => (
-              <div>
-                <button
-                  onClick={async () => {
-                    const res = await rejoinPatchFetch({
-                      socialId,
-                      rejoin: true,
-                    });
-                    setUserContext(res.data);
-                  }}
-                >
-                  네
-                </button>
-                <button
-                  onClick={async () => {
-                    await rejoinPatchFetch({ socialId, rejoin: false });
-                    close(false);
-                    unmount();
-                  }}
-                >
-                  아니오
-                </button>
-              </div>
+              <FullModal
+                modalType="account-reactive"
+                modalHandler={async () => {
+                  const res = await rejoinPatchFetch({
+                    socialId,
+                    rejoin: true,
+                  });
+                  setUserContext(res.data);
+                }}
+                cancelModalHandler={async () => {
+                  await rejoinPatchFetch({ socialId, rejoin: false });
+                  close(false);
+                  unmount();
+                }}
+              />
             ),
           );
           if (!agreeActivateAccount) {

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import useAuth from '@/hooks/useAuth';
+import { useSetAtom } from 'jotai';
+import { socialIdAtom, isTutorialFinished } from '@/stores/signup';
+import { overlay } from 'overlay-kit';
+import {
+  KakaoAuthFetchResponse,
+  kakaoAuthFetch,
+} from '@/api/auth/login/kakaoAuthFetch';
+import { rejoinPatchFetch } from '@/api/auth/rejoin/rejoinPatchFetch';
+
+const useKakaoLogin = () => {
+  const setSocialId = useSetAtom(socialIdAtom);
+  const setTutorialFinished = useSetAtom(isTutorialFinished);
+  const router = useRouter();
+  const { setAccessToken, setRefreshToken, setUserType } = useAuth();
+
+  const setUserContext = (userRes: KakaoAuthFetchResponse) => {
+    const {
+      accessExpiration,
+      accessToken,
+      refreshToken,
+      role,
+      isTutorial,
+      refreshExpiration,
+      socialId,
+    } = userRes.data;
+
+    setAccessToken({ token: accessToken, expires: accessExpiration });
+    setRefreshToken({ token: refreshToken, expires: refreshExpiration });
+    setUserType(role);
+    setTutorialFinished(isTutorial);
+    setSocialId(socialId);
+  };
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+
+    const fetchKakaoData = async () => {
+      try {
+        const { data: kakaoAuthFetchRes } = await kakaoAuthFetch({
+          code: code ?? '',
+        });
+
+        const { socialId, isDelete } = kakaoAuthFetchRes.data;
+
+        if (kakaoAuthFetchRes.code === 'AU204') {
+          setUserContext(kakaoAuthFetchRes);
+          router.replace('/');
+          return;
+        }
+
+        if (isDelete) {
+          const agreeActivateAccount = await overlay.openAsync<boolean>(
+            ({ close, unmount }) => (
+              <div>
+                <button
+                  onClick={async () => {
+                    const res = await rejoinPatchFetch({
+                      socialId,
+                      rejoin: true,
+                    });
+                    setUserContext(res.data);
+                  }}
+                >
+                  네
+                </button>
+                <button
+                  onClick={async () => {
+                    await rejoinPatchFetch({ socialId, rejoin: false });
+                    close(false);
+                    unmount();
+                  }}
+                >
+                  아니오
+                </button>
+              </div>
+            ),
+          );
+          if (!agreeActivateAccount) {
+            router.push('/signup/select');
+          }
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchKakaoData();
+  }, []);
+};
+
+export default useKakaoLogin;

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -71,7 +71,6 @@ const useKakaoLogin = () => {
                     () => {
                       close(false);
                       unmount();
-                      router.push('/');
                     },
                   );
                 }}

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -67,9 +67,13 @@ const useKakaoLogin = () => {
                   setUserContext(res.data);
                 }}
                 cancelModalHandler={async () => {
-                  await rejoinPatchFetch({ socialId, rejoin: false });
-                  close(false);
-                  unmount();
+                  await rejoinPatchFetch({ socialId, rejoin: false }).then(
+                    () => {
+                      close(false);
+                      unmount();
+                      router.push('/');
+                    },
+                  );
                 }}
               />
             ),

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -6,7 +6,11 @@ function useModal(portalId: string) {
   const [portalElement, setPortalElement] = useState<Element | null>(null);
 
   useEffect(() => {
-    setPortalElement(document.getElementById(portalId));
+    const portalIdEl = document.getElementById(portalId);
+    if (!portalIdEl) {
+      return;
+    }
+    setPortalElement(portalIdEl);
   }, [modal]);
 
   const modalHandler = () => {

--- a/src/lib/overlay.tsx
+++ b/src/lib/overlay.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { OverlayProvider } from 'overlay-kit';
+import { ReactNode } from 'react';
+export default function OverlayKitProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <OverlayProvider>{children}</OverlayProvider>;
+}

--- a/src/types/modal/full.ts
+++ b/src/types/modal/full.ts
@@ -11,7 +11,8 @@ export type FullModalType =
   | 'senior-mentoring-time'
   | 'senior-mentoring-spec'
   | 'select-date-calendar'
-  | 'junior-mentoring-spec';
+  | 'junior-mentoring-spec'
+  | 'account-reactive';
 
 export interface FullModalProps {
   modalType: FullModalType;


### PR DESCRIPTION
## 🦝 PR 요약
탈퇴 후 다시 로그인 시 15일 이내의 경우 재활성화 여부를 입력받고 재로그인 하는 로직 구현

## ✨ PR 상세 내용
탈퇴 후 재로그인 흐름을 구현하였습니다. 크게 아래의 흐름을 갖게 됩니당.

탈퇴 진행 ->  재로그인  -> 재가입 여부 모달 -> 재가입 원할 시 재가입 진행 -> 재가입 원하지 않을 시 다시 로그인X
흐름은 아래 원준님이 잘 정리해준 노션을 보면 이해가 쉽게 됩니당! 💅 

https://www.notion.so/88991f7c1afe4f4688b5bec9810f3e35

카카오 로그인의 로직을 한번에 관리하고자 따로 커스텀 훅을 만들어서 뺐는데, 어느정도의 로직이 컴포넌트에 들어가는 게 좋을지 모르겠네요,, 사실 커스텀 훅으로 잘 뺐는지도 모르겠습니다.. 다들 알찬 피드백...주십숑 🍰 

그리고 요 부분은 이상하다 아니면 좀 더 좋은 코드가 될 것 같다 싶으면 리뷰리뷰리뷰 주세요.. 🧷 

## 🚨 주의 사항
overlay-kit를 설치하고 Provider를 주입해주었씁니다. 모달을 선언적으로 관리할 수 있고, 번들 크기도 굉장히 작고 여러므로 유용할 것 같아요! 

뒤섞인 모달을 잘 정리하는데 유용할 것 같습니당! 
## 📸 스크린샷

https://github.com/user-attachments/assets/9894338e-664a-4c52-9676-e2dea6a56566


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
