### PR TITLE
RAC-430 Refactor: FullModal 부분 리팩토링

### DIFF
--- a/src/app/add-profile/page.tsx
+++ b/src/app/add-profile/page.tsx
@@ -7,7 +7,6 @@ import BackHeader from '@/components/Header/BackHeader';
 
 import { FieldError, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import FullModal from '@/components/Modal/FullModal';
 import ProfileForm from '@/components/SingleForm/ProfileForm';
 import SingleValidator from '@/components/Validator/SingleValidator';
 
@@ -17,7 +16,6 @@ import {
   PROFILE_SUB_DIRECTION,
   PROFILE_TITLE,
 } from '@/constants/form/cProfileForm';
-import useModal from '@/hooks/useModal';
 import {
   sMultiIntroduce,
   sRecommendedFor,
@@ -25,16 +23,19 @@ import {
 } from '@/stores/senior';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
-import { createPortal } from 'react-dom';
 import styled from 'styled-components';
+import useFullModal from '@/hooks/useFullModal';
 
 function AddProfilePage() {
+  const { openModal } = useFullModal({
+    modalType: 'best-case',
+    modalHandler: () => {},
+  });
   const [singleIntro, setSingleIntro] = useAtom(sSingleIntroduce);
   const [multiIntro, setMultiIntro] = useAtom(sMultiIntroduce);
   const [recommended, setRecommended] = useAtom(sRecommendedFor);
   const {
     register,
-    trigger,
     handleSubmit,
     formState: { errors },
   } = useForm({
@@ -48,9 +49,7 @@ function AddProfilePage() {
   });
 
   const router = useRouter();
-  const { modal, modalHandler, portalElement } = useModal(
-    'senior-best-case-portal',
-  );
+
   const hasErrors =
     errors.multiIntro || errors.recommended || errors.singleIntro;
 
@@ -126,7 +125,7 @@ function AddProfilePage() {
           />
         )}
       </div>
-      <ShowProfBtn onClick={modalHandler}>프로필 예시 보기</ShowProfBtn>
+      <ShowProfBtn onClick={openModal}>프로필 예시 보기</ShowProfBtn>
       <div style={{ display: 'flex', marginTop: '2rem' }}>
         <PrevBtn
           onClick={() => {
@@ -139,12 +138,6 @@ function AddProfilePage() {
           다음
         </NextAddBtnSet>
       </div>
-      {modal && portalElement
-        ? createPortal(
-            <FullModal modalType="best-case" modalHandler={modalHandler} />,
-            portalElement,
-          )
-        : null}
     </AddProfilePageContainer>
   );
 }

--- a/src/app/add-profile/page.tsx
+++ b/src/app/add-profile/page.tsx
@@ -29,7 +29,6 @@ import useFullModal from '@/hooks/useFullModal';
 function AddProfilePage() {
   const { openModal } = useFullModal({
     modalType: 'best-case',
-    modalHandler: () => {},
   });
   const [singleIntro, setSingleIntro] = useAtom(sSingleIntroduce);
   const [multiIntro, setMultiIntro] = useAtom(sMultiIntroduce);

--- a/src/app/junior/mentoring/page.tsx
+++ b/src/app/junior/mentoring/page.tsx
@@ -1,20 +1,14 @@
 'use client';
 import TapBar from '@/components/Bar/TapBar/JuniorTab/JTabBar';
 import React, { useEffect } from 'react';
-import { createPortal } from 'react-dom';
-import useModal from '@/hooks/useModal';
 import styled from 'styled-components';
 import MenuBar from '@/components/Bar/MenuBar';
 import LogoLayer from '@/components/LogoLayer/LogoLayer';
 import SearchModal from '@/components/Modal/SearchModal';
+import { overlay } from 'overlay-kit';
 import useAuth from '@/hooks/useAuth';
 
 function JuniorMentoringPage() {
-  const {
-    modal: searchModal,
-    modalHandler: searchModalHandler,
-    portalElement: searchPortalElement,
-  } = useModal('search-portal');
   const { getAccessToken } = useAuth();
 
   useEffect(() => {
@@ -31,19 +25,17 @@ function JuniorMentoringPage() {
     });
   }, []);
 
+  const openSearchModal = () => {
+    overlay.open(({ unmount }) => <SearchModal modalHandler={unmount} />);
+  };
+
   return (
     <div style={{ width: 'inherit', height: 'inherit' }}>
-      <LogoLayer modalHandler={searchModalHandler} />
+      <LogoLayer modalHandler={openSearchModal} />
       <TapBar />
       <MenuBarWrapper>
-        <MenuBar modalHandler={searchModalHandler} />
+        <MenuBar modalHandler={openSearchModal} />
       </MenuBarWrapper>
-      {searchModal && searchPortalElement
-        ? createPortal(
-            <SearchModal modalHandler={searchModalHandler} />,
-            searchPortalElement,
-          )
-        : ''}
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,24 +30,15 @@ export default function RootLayout({
             <OverlayKitProvider>
               {children}
               <div id="senior-info-portal"></div>
-              <div id="junior-mentoring-detail"></div>
               <div id="junior-mentoring-cancel"></div>
               <div id="senior-profile-portal"></div>
-              <div id="login-request-portal"></div>
-              <div id="senior-best-case-portal"></div>
               <div id="login-request-full-portal"></div>
               <div id="search-portal"></div>
-              <div id="senior-my-profile-portal"></div>
               <div id="senior-request-portal"></div>
               <div id="junior-request-portal"></div>
               <div id="profile-modify-portal"></div>
-              <div id="senior-mentoring-detail"></div>
               <div id="senior-mentoring-cancel"></div>
-              <div id="senior-mentoring-accept"></div>
-              <div id="senior-info-modify-portal"></div>
-              <div id="senior-mentoring-time-portal"></div>
               <div id="senior-profile-not-registered"></div>
-              <div id="select-date-calendar"></div>
               <div id="suggest-mypage-portal"></div>
               <div id="senior-auth-portal"></div>
               <div id="mentoring-login-portal"></div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,6 @@ export default function RootLayout({
               <div id="junior-mentoring-cancel"></div>
               <div id="senior-profile-portal"></div>
               <div id="login-request-full-portal"></div>
-              <div id="search-portal"></div>
               <div id="senior-request-portal"></div>
               <div id="junior-request-portal"></div>
               <div id="profile-modify-portal"></div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -9,7 +9,6 @@ import { useAtom } from 'jotai';
 import NotLmypage from '../../components/NotLogin/NotLmypage/NotLmypage';
 import useModal from '../../hooks/useModal';
 import { createPortal } from 'react-dom';
-import FullModal from '../../components/Modal/FullModal';
 import DimmedModal from '../../components/Modal/DimmedModal';
 import { userType } from '../../types/user/user';
 import SalaryBox from '../../components/Box/SalaryBox';
@@ -23,6 +22,7 @@ import findExCode from '@/utils/findExCode';
 import Footer from '@/components/Footer';
 import { certifiRegAtom, profileRegAtom } from '@/stores/signup';
 import { useRouter } from 'next/navigation';
+import useFullModal from '@/hooks/useFullModal';
 
 function MyPage() {
   const [nickName, setnickName] = useState<string | null>(null);
@@ -32,9 +32,7 @@ function MyPage() {
   const [certifiReg, setCertifiReg] = useAtom(certifiRegAtom);
   const [profileReg, setProfileReg] = useAtom(profileRegAtom);
   const [senior, setSenior] = useAtom(mySeniorId);
-  const { modal, modalHandler, portalElement } = useModal(
-    'login-request-full-portal',
-  );
+
   const {
     modal: BModal,
     modalHandler: BModalHandler,
@@ -55,21 +53,22 @@ function MyPage() {
     modalHandler: suggestModalHandler,
     portalElement: suggesPortalElement,
   } = useModal('suggest-mypage-portal');
-  const {
-    modal: infoModal,
-    modalHandler: infoHandler,
-    portalElement: infoPortalElement,
-  } = useModal('senior-info-modify-portal');
+
   const {
     modal: authModal,
     modalHandler: authHandler,
     portalElement: authPortalElement,
   } = useModal('senior-auth-portal');
-  const {
-    modal: loginRequestModal,
-    modalHandler: loginRequestHandler,
-    portalElement: loginRequestElement,
-  } = useModal('login-request-portal');
+
+  const { openModal: openSeniorInfoModifyModal } = useFullModal({
+    modalType: 'senior-info-modify',
+    modalHandler: () => {},
+  });
+
+  const { openModal: openLoginRequestModal } = useFullModal({
+    modalType: 'login-request',
+    modalHandler: () => {},
+  });
 
   const { getAccessToken, getUserType, removeTokens } = useAuth();
   const [accessTkn, setAccessTkn] = useState('');
@@ -178,7 +177,7 @@ function MyPage() {
           />
         </div>
       ) : (
-        <NotLmypage modalHandler={modalHandler}></NotLmypage>
+        <NotLmypage modalHandler={openLoginRequestModal}></NotLmypage>
       )}
       <div
         style={{
@@ -191,13 +190,7 @@ function MyPage() {
         <CustomerCenter />
         <Footer />
       </div>
-      <MenuBar modalHandler={loginRequestHandler} />
-      {modal && portalElement
-        ? createPortal(
-            <FullModal modalType="login-request" modalHandler={modalHandler} />,
-            portalElement,
-          )
-        : ''}
+      <MenuBar modalHandler={openLoginRequestModal} />
       {seniorChangemodal && seniorChangePortalElement
         ? createPortal(
             <DimmedModal
@@ -217,21 +210,13 @@ function MyPage() {
         ? createPortal(
             <DimmedModal
               modalType="mypageSuggest"
-              infoHandler={infoHandler}
+              infoHandler={openSeniorInfoModifyModal}
               modalHandler={suggestModalHandler}
             />,
             suggesPortalElement,
           )
         : ''}
-      {infoModal && infoPortalElement
-        ? createPortal(
-            <FullModal
-              modalType="senior-info-modify"
-              modalHandler={infoHandler}
-            />,
-            infoPortalElement,
-          )
-        : null}
+
       {BModal && BPotalElement
         ? createPortal(
             <RiseUpModal modalHandler={BModalHandler} modalType={'bank'} />,
@@ -246,15 +231,6 @@ function MyPage() {
               modalHandler={authHandler}
             />,
             authPortalElement,
-          )
-        : null}
-      {loginRequestModal && loginRequestElement
-        ? createPortal(
-            <DimmedModal
-              modalType="notuser"
-              modalHandler={loginRequestHandler}
-            />,
-            loginRequestElement,
           )
         : null}
     </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -62,12 +62,10 @@ function MyPage() {
 
   const { openModal: openSeniorInfoModifyModal } = useFullModal({
     modalType: 'senior-info-modify',
-    modalHandler: () => {},
   });
 
   const { openModal: openLoginRequestModal } = useFullModal({
     modalType: 'login-request',
-    modalHandler: () => {},
   });
 
   const { getAccessToken, getUserType, removeTokens } = useAuth();

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -44,11 +44,9 @@ function MyPage() {
     modalHandler: seiorChangemodalHandler,
     portalElement: seniorChangePortalElement,
   } = useModal('senior-request-portal');
-  const {
-    modal: searchModal,
-    modalHandler: searchModalHandler,
-    portalElement: searchPortalElement,
-  } = useModal('search-portal');
+  const openSearchModal = () => {
+    overlay.open(({ unmount }) => <SearchModal modalHandler={unmount} />);
+  };
   const {
     modal: suggestModal,
     modalHandler: suggestModalHandler,
@@ -146,7 +144,7 @@ function MyPage() {
     <div
       style={{ backgroundColor: '#F8F9FA', width: 'inherit', height: '100vh' }}
     >
-      <LogoLayer modalHandler={searchModalHandler} />
+      <LogoLayer modalHandler={openSearchModal} />
       {accessTkn ? (
         <div style={{ backgroundColor: '#F8F9FA', marginTop: '1rem' }}>
           <Profile
@@ -199,12 +197,7 @@ function MyPage() {
             seniorChangePortalElement,
           )
         : ''}
-      {searchModal && searchPortalElement
-        ? createPortal(
-            <SearchModal modalHandler={searchModalHandler} />,
-            searchPortalElement,
-          )
-        : ''}
+
       {suggestModal && suggesPortalElement
         ? createPortal(
             <DimmedModal

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -23,6 +23,7 @@ import Footer from '@/components/Footer';
 import { certifiRegAtom, profileRegAtom } from '@/stores/signup';
 import { useRouter } from 'next/navigation';
 import useFullModal from '@/hooks/useFullModal';
+import { overlay } from 'overlay-kit';
 
 function MyPage() {
   const [nickName, setnickName] = useState<string | null>(null);
@@ -215,12 +216,6 @@ function MyPage() {
           )
         : ''}
 
-      {BModal && BPotalElement
-        ? createPortal(
-            <RiseUpModal modalHandler={BModalHandler} modalType={'bank'} />,
-            BPotalElement,
-          )
-        : null}
       {authModal && authPortalElement
         ? createPortal(
             <DimmedModal

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import SeniorProfile from '../components/SeniorProfile/SeniorProfile';
 import FieldTapBar from '../components/Bar/FieldTapBar/FieldTapBar';
 import UnivTapBar from '../components/Bar/UnivTapBar/UnivTapBar';
 import SwiperComponent from '../components/Swiper/Swiper';
-import useModal from '../hooks/useModal';
 import DimmedModal from '../components/Modal/DimmedModal';
 import SearchModal from '../components/Modal/SearchModal';
 import { sfactiveTabAtom, suactiveTabAtom } from '../stores/tap';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,13 +83,15 @@ export default function Home() {
     };
   }, [page]);
 
-  const { modal, modalHandler } = useModal('');
-
-  const { modal: searchModal, modalHandler: searchModalHandler } = useModal('');
-
   return (
     <HomeLayer>
-      <LogoLayer modalHandler={searchModalHandler} />
+      <LogoLayer
+        modalHandler={() => {
+          overlay.open(({ unmount }) => {
+            return <SearchModal modalHandler={() => unmount()} />;
+          });
+        }}
+      />
       <HomeBannerLayer>
         <SwiperComponent />
       </HomeBannerLayer>
@@ -112,32 +114,19 @@ export default function Home() {
       </HomeProfileLayer>
       <Footer />
       <MenuBarWrapper>
-        <MenuBar modalHandler={modalHandler} />
+        <MenuBar
+          modalHandler={() => {
+            overlay.open(({ unmount }) => {
+              return (
+                <DimmedModal
+                  modalType="notuser"
+                  modalHandler={() => unmount()}
+                />
+              );
+            });
+          }}
+        />
       </MenuBarWrapper>
-
-      {modal
-        ? overlay.open(({ unmount }) => {
-            return (
-              <DimmedModal
-                modalType="notuser"
-                modalHandler={() => {
-                  unmount();
-                }}
-              />
-            );
-          })
-        : ''}
-      {searchModal
-        ? overlay.open(({ unmount }) => {
-            return (
-              <SearchModal
-                modalHandler={() => {
-                  unmount();
-                }}
-              />
-            );
-          })
-        : ''}
     </HomeLayer>
   );
 }

--- a/src/app/search-results/page.tsx
+++ b/src/app/search-results/page.tsx
@@ -8,9 +8,7 @@ import axios from 'axios';
 import Image from 'next/image';
 import arrow from '../../../public/arrow.png';
 import SearchDropDown from '@/components/DropDown/SearchDropDown';
-import useModal from '@/hooks/useModal';
 import SearchModal from '@/components/Modal/SearchModal';
-import { createPortal } from 'react-dom';
 import Spinner from '@/components/Spinner';
 import { SeniorProfileData } from '@/types/profile/seniorProfile';
 
@@ -23,11 +21,6 @@ function SearchResultPage() {
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [length, setLength] = useState(0);
-  const {
-    modal: searchModal,
-    modalHandler: searchModalHandler,
-    portalElement: searchPortalElement,
-  } = useModal('search-portal');
 
   useEffect(() => {
     setIsLoading(true);
@@ -110,9 +103,6 @@ function SearchResultPage() {
             }}
           />
         </SearchReasultOut>
-        <SearchReasultTerm onClick={searchModalHandler}>
-          {searchTerm}
-        </SearchReasultTerm>
       </SearchReasult>
       <Searchfilter>
         <SearchFcount>총 {length}건</SearchFcount>
@@ -136,12 +126,6 @@ function SearchResultPage() {
           <div>해당하는 선배가 없어요</div>
         )}
       </SearchReasultProfile>
-      {searchModal && searchPortalElement
-        ? createPortal(
-            <SearchModal modalHandler={searchModalHandler} />,
-            searchPortalElement,
-          )
-        : ''}
     </>
   );
 }

--- a/src/app/senior/edit-profile/page.tsx
+++ b/src/app/senior/edit-profile/page.tsx
@@ -34,17 +34,19 @@ import { useAtom, useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import useFullModal from '@/hooks/useFullModal';
 import styled from 'styled-components';
 
 function EditProfilePage() {
   const { getAccessToken, removeTokens } = useAuth();
   const [modalType, setModalType] = useState<ModalType>('postgradu');
   const { modal, modalHandler, portalElement } = useModal('senior-info-portal');
-  const {
-    modal: timeModal,
-    modalHandler: timeModalHandler,
-    portalElement: timePortalElement,
-  } = useModal('senior-mentoring-time-portal');
+
+  const { openModal: openSeniorMentoringTimeModal } = useFullModal({
+    modalHandler: () => {},
+    modalType: 'senior-mentoring-time',
+  });
+
   const [flag, setFlag] = useState(false);
   const [labFlag, setLabFlag] = useState(false);
   const [fieldFlag, setFieldFlag] = useState(false);
@@ -452,7 +454,7 @@ function EditProfilePage() {
                 >
                   <div
                     id="setData-btn"
-                    onClick={timeModalHandler}
+                    onClick={openSeniorMentoringTimeModal}
                     style={{ cursor: 'pointer' }}
                   >
                     추가하기
@@ -462,7 +464,7 @@ function EditProfilePage() {
             ) : (
               <SetDataForm>
                 <div id="setDataF-msg">입력된 정기 일정이 없습니다.</div>
-                <div id="setData-btn" onClick={timeModalHandler}>
+                <div id="setData-btn" onClick={openSeniorMentoringTimeModal}>
                   + 추가하기
                 </div>
               </SetDataForm>
@@ -485,15 +487,6 @@ function EditProfilePage() {
         ? createPortal(
             <RiseUpModal modalHandler={modalHandler} modalType={modalType} />,
             portalElement,
-          )
-        : null}
-      {timeModal && timePortalElement
-        ? createPortal(
-            <FullModal
-              modalType="senior-mentoring-time"
-              modalHandler={timeModalHandler}
-            />,
-            timePortalElement,
           )
         : null}
     </div>

--- a/src/app/senior/edit-profile/page.tsx
+++ b/src/app/senior/edit-profile/page.tsx
@@ -43,7 +43,6 @@ function EditProfilePage() {
   const { modal, modalHandler, portalElement } = useModal('senior-info-portal');
 
   const { openModal: openSeniorMentoringTimeModal } = useFullModal({
-    modalHandler: () => {},
     modalType: 'senior-mentoring-time',
   });
 

--- a/src/app/senior/mentoring/page.tsx
+++ b/src/app/senior/mentoring/page.tsx
@@ -3,19 +3,16 @@ import STapBar from '@/components/Bar/TapBar/SeniorTab/STabBar';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import useAuth from '@/hooks/useAuth';
-import { createPortal } from 'react-dom';
-import useModal from '@/hooks/useModal';
 import LogoLayer from '@/components/LogoLayer/LogoLayer';
 import MenuBar from '@/components/Bar/MenuBar';
 import SearchModal from '@/components/Modal/SearchModal';
+import { overlay } from 'overlay-kit';
 
 function SeniorMentoringPage() {
-  const {
-    modal: searchModal,
-    modalHandler: searchModalHandler,
-    portalElement: searchPortalElement,
-  } = useModal('search-portal');
   const { getAccessToken } = useAuth();
+  const openSearchModal = () => {
+    overlay.open(({ unmount }) => <SearchModal modalHandler={unmount} />);
+  };
 
   useEffect(() => {
     getAccessToken().then((tkn) => {
@@ -33,17 +30,11 @@ function SeniorMentoringPage() {
 
   return (
     <div style={{ width: 'inherit', height: 'inherit' }}>
-      <LogoLayer modalHandler={searchModalHandler} />
+      <LogoLayer modalHandler={openSearchModal} />
       <STapBar />
       <MenuBarWrapper>
-        <MenuBar modalHandler={searchModalHandler} />
+        <MenuBar modalHandler={openSearchModal} />
       </MenuBarWrapper>
-      {searchModal && searchPortalElement
-        ? createPortal(
-            <SearchModal modalHandler={searchModalHandler} />,
-            searchPortalElement,
-          )
-        : ''}
     </div>
   );
 }

--- a/src/app/signup/select/common-info/senior-info/major/page.tsx
+++ b/src/app/signup/select/common-info/senior-info/major/page.tsx
@@ -7,6 +7,7 @@ import useModal from '@/hooks/useModal';
 import { sMajorAtom, sPostGraduAtom } from '@/stores/senior';
 import { ModalType } from '@/types/modal/riseUp';
 import { useAtomValue } from 'jotai';
+import { overlay } from 'overlay-kit';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -22,9 +22,9 @@ import useModal from '@/hooks/useModal';
 import { ModalMentoringType } from '@/types/modal/mentoringDetail';
 import { createPortal } from 'react-dom';
 import DimmedModal from '@/components/Modal/DimmedModal';
-import FullModal from '@/components/Modal/FullModal';
 import { useRouter } from 'next/navigation';
 import findExCode from '@/utils/findExCode';
+import useFullModal from '@/hooks/useFullModal';
 import { JMCancelAtom } from '@/stores/condition';
 import { REVIEW_FORM_URL } from '@/constants/form/reviewForm';
 import { StyledSModalBtn } from '@/components/Button/ModalBtn/ModalBtn.styled';
@@ -42,6 +42,10 @@ function convertDateType(date: string) {
   return new Date(year, month, day, hour, minute);
 }
 function TabBar() {
+  const { openModal: openJuniorMentoringSpecModal } = useFullModal({
+    modalType: 'junior-mentoring-spec',
+    modalHandler: () => {},
+  });
   const router = useRouter();
   const [modalType, setModalType] = useState<ModalMentoringType>('junior');
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
@@ -50,9 +54,7 @@ function TabBar() {
     setActiveTab(tabIndex);
   };
   const { getAccessToken, removeTokens } = useAuth();
-  const { modal, modalHandler, portalElement } = useModal(
-    'junior-mentoring-detail',
-  );
+
   const {
     modal: cancelModal,
     modalHandler: cancelModalHandler,
@@ -146,7 +148,7 @@ function TabBar() {
                   <ModalBtn
                     type={'show'}
                     btnText={'내 신청서 보기'}
-                    modalHandler={modalHandler}
+                    modalHandler={openJuniorMentoringSpecModal}
                     onClick={() => {
                       setModalType('junior');
                       setSelectedMentoringId(el.mentoringId);
@@ -171,7 +173,7 @@ function TabBar() {
                       <ModalBtn
                         type={'show'}
                         btnText={'내 신청서 보기'}
-                        modalHandler={modalHandler}
+                        modalHandler={openJuniorMentoringSpecModal}
                         onClick={() => {
                           setModalType('junior');
                           setSelectedMentoringId(el.mentoringId);
@@ -229,17 +231,7 @@ function TabBar() {
       <TabResultContainer>
         <TabResult>{renderTabContent()}</TabResult>
       </TabResultContainer>
-      {modal && portalElement
-        ? createPortal(
-            <FullModal
-              modalType="junior-mentoring-spec"
-              modalHandler={modalHandler}
-              cancelModalHandler={cancelModalHandler}
-              mentoringId={selectedMentoringId || 0}
-            />,
-            portalElement,
-          )
-        : null}
+
       {cancelModal && cancelPortalElement
         ? createPortal(
             <DimmedModal

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -44,7 +44,6 @@ function convertDateType(date: string) {
 function TabBar() {
   const { openModal: openJuniorMentoringSpecModal } = useFullModal({
     modalType: 'junior-mentoring-spec',
-    modalHandler: () => {},
   });
   const router = useRouter();
   const [modalType, setModalType] = useState<ModalMentoringType>('junior');

--- a/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
+++ b/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
@@ -3,12 +3,10 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import {
   TapStyle,
-  MentoringMapBox,
   TabWrap,
   TabResultContainer,
   TabResult,
   MentoringBox,
-  DoneBtnBox,
   NoMentoring,
 } from './STabBrar.styled';
 import { useAtom, useAtomValue } from 'jotai';
@@ -21,16 +19,14 @@ import MentoringApply from '@/components/Mentoring/MentoringApply/MentoringApply
 import ModalBtn from '@/components/Button/ModalBtn';
 import useModal from '@/hooks/useModal';
 import { ModalMentoringType } from '@/types/modal/mentoringDetail';
-import MentoringSpec from '@/components/Mentoring/MentoringSpec/JmentoringSpec';
 import { createPortal } from 'react-dom';
-import MentoringCancel from '@/components/Mentoring/MentoringCancel/MentoringCancel';
-import SmentoringSpec from '@/components/Mentoring/MentoringSpec/SmentoringSpec/SmentoringSpec';
 import DimmedModal from '@/components/Modal/DimmedModal';
 import FullModal from '@/components/Modal/FullModal';
 import AccountShowBtn from '@/components/Button/AccountShowBtn/AccountShowBtn';
 import SmentoringCancel from '@/components/Mentoring/SmentoringCancel/SmentoringCancel';
 import { useRouter } from 'next/navigation';
 import findExCode from '@/utils/findExCode';
+import useFullModal from '@/hooks/useFullModal';
 import { SMCancelAtom } from '@/stores/condition';
 function STabBar() {
   const router = useRouter();
@@ -40,20 +36,24 @@ function STabBar() {
   const handleTabClick = (tabIndex: tapType) => {
     setActiveTab(tabIndex);
   };
+
+  const { openModal: openSeniorMentoringSpecModal } = useFullModal({
+    modalType: 'senior-mentoring-spec',
+    modalHandler: () => {},
+  });
+
+  const { openModal: openAcceptMentoringModal } = useFullModal({
+    modalHandler: () => {},
+    modalType: 'accept-mentoring',
+  });
   const { getAccessToken, removeTokens } = useAuth();
-  const { modal, modalHandler, portalElement } = useModal(
-    'senior-mentoring-detail',
-  );
+
   const {
     modal: cancelModal,
     modalHandler: cancelModalHandler,
     portalElement: cancelPortalElement,
   } = useModal('senior-mentoring-cancel');
-  const {
-    modal: acceptModal,
-    modalHandler: acceptModalHandler,
-    portalElement: acceptPortalElement,
-  } = useModal('senior-mentoring-accept');
+
   const {
     modal: successModal,
     modalHandler: successModalHandler,
@@ -117,7 +117,7 @@ function STabBar() {
                         ? '신청서 보고 수락하기'
                         : '신청서 보기'
                     }
-                    modalHandler={modalHandler}
+                    modalHandler={openSeniorMentoringSpecModal}
                     onClick={() => {
                       setModalType('senior');
                       setSelectedMentoringId(el.mentoringId);
@@ -174,18 +174,7 @@ function STabBar() {
       <TabResultContainer>
         <TabResult>{renderTabContent()}</TabResult>
       </TabResultContainer>
-      {modal && portalElement
-        ? createPortal(
-            <FullModal
-              modalType="senior-mentoring-spec"
-              modalHandler={modalHandler}
-              cancelModalHandler={cancelModalHandler}
-              acceptModalHandler={acceptModalHandler}
-              mentoringId={selectedMentoringId || 0}
-            />,
-            portalElement,
-          )
-        : null}
+
       {cancelModal && cancelPortalElement
         ? createPortal(
             <SmentoringCancel
@@ -196,15 +185,7 @@ function STabBar() {
             cancelPortalElement,
           )
         : null}
-      {acceptModal && acceptPortalElement
-        ? createPortal(
-            <FullModal
-              modalType="accept-mentoring"
-              modalHandler={acceptModalHandler}
-            />,
-            acceptPortalElement,
-          )
-        : null}
+
       {successModal && cancelPortalElement
         ? createPortal(
             <DimmedModal

--- a/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
+++ b/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
@@ -39,12 +39,10 @@ function STabBar() {
 
   const { openModal: openSeniorMentoringSpecModal } = useFullModal({
     modalType: 'senior-mentoring-spec',
-    modalHandler: () => {},
   });
 
   const { openModal: openAcceptMentoringModal } = useFullModal({
     modalHandler: () => {},
-    modalType: 'accept-mentoring',
   });
   const { getAccessToken, removeTokens } = useAuth();
 

--- a/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
+++ b/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
@@ -37,12 +37,8 @@ function STabBar() {
     setActiveTab(tabIndex);
   };
 
-  const { openModal: openSeniorMentoringSpecModal } = useFullModal({
-    modalType: 'senior-mentoring-spec',
-  });
-
   const { openModal: openAcceptMentoringModal } = useFullModal({
-    modalHandler: () => {},
+    modalType: 'accept-mentoring',
   });
   const { getAccessToken, removeTokens } = useAuth();
 
@@ -61,6 +57,14 @@ function STabBar() {
     null,
   );
   const [prevMentoringInfoLength, setPrevMentoringInfoLength] = useState(0);
+
+  const { openModal: openSeniorMentoringSpecModal } = useFullModal({
+    modalType: 'senior-mentoring-spec',
+    mentoringId: selectedMentoringId ?? 0,
+    cancelModalHandler: cancelModalHandler,
+    acceptModalHandler: openAcceptMentoringModal,
+  });
+
   const SMCancel = useAtomValue(SMCancelAtom);
   useEffect(() => {
     if (SMCancel === true) {

--- a/src/components/Content/MBestCaseContent/MBestCaseContent.tsx
+++ b/src/components/Content/MBestCaseContent/MBestCaseContent.tsx
@@ -1,13 +1,6 @@
 import { MBestCaseContainer } from './MBestCaseContent.styled';
 import Image from 'next/image';
 import bestCase from '@/../../public/best_sample.png';
-import x_icon from '../../../../public/x.png';
-import user_img from '../../../../public/user.png';
-import RoundedImage from '@/components/Image/RoundedImage';
-import DividedText from '@/components/Text/DividedText';
-import AuthLabeledText from '@/components/Text/AuthLabeledText';
-import BorderedText from '@/components/Text/BorderedText';
-import TextField from '@/components/Text/TextField';
 import BackHeader from '@/components/Header/BackHeader';
 
 function MBestCaseContent({ modalHandler }: { modalHandler: () => void }) {

--- a/src/components/Content/ProfileModify/ProfileModify.tsx
+++ b/src/components/Content/ProfileModify/ProfileModify.tsx
@@ -29,6 +29,7 @@ import {
 import Scheduler from '@/components/Scheduler';
 import { useRouter } from 'next/navigation';
 import findExCode from '@/utils/findExCode';
+import { overlay } from 'overlay-kit';
 
 function ProfileModify({ modalHandler }: { modalHandler: () => void }) {
   const router = useRouter();
@@ -45,11 +46,6 @@ function ProfileModify({ modalHandler }: { modalHandler: () => void }) {
   const [times, setTimes] = useAtom(sAbleTime);
   const [submitFlag, setSubmitFlag] = useState(false);
   const { getAccessToken, removeTokens } = useAuth();
-  const {
-    modal,
-    modalHandler: infoHandler,
-    portalElement,
-  } = useModal('senior-info-portal');
 
   useEffect(() => {
     getAccessToken().then((accessTkn) => {
@@ -91,12 +87,30 @@ function ProfileModify({ modalHandler }: { modalHandler: () => void }) {
 
   const clickKeyword = () => {
     setModalType('keyword');
-    infoHandler();
+    overlay.open(({ unmount }) => {
+      return (
+        <RiseUpModal
+          modalType="keyword"
+          modalHandler={() => {
+            unmount();
+          }}
+        />
+      );
+    });
   };
 
   const clickField = () => {
     setModalType('field');
-    infoHandler();
+    overlay.open(({ unmount }) => {
+      return (
+        <RiseUpModal
+          modalType="keyword"
+          modalHandler={() => {
+            unmount();
+          }}
+        />
+      );
+    });
   };
 
   const dedupeInTotalField = (fields: Array<string>) => {
@@ -249,12 +263,6 @@ function ProfileModify({ modalHandler }: { modalHandler: () => void }) {
       <SaveBtnBox>
         <ClickedBtn kind="click" btnText="저장" clickHandler={submitHandler} />
       </SaveBtnBox>
-      {modal && portalElement
-        ? createPortal(
-            <RiseUpModal modalHandler={infoHandler} modalType={modalType} />,
-            portalElement,
-          )
-        : null}
     </PMContainer>
   );
 }

--- a/src/components/Content/ProfileModify/ProfileModify.tsx
+++ b/src/components/Content/ProfileModify/ProfileModify.tsx
@@ -15,8 +15,6 @@ import SingleValidator from '@/components/Validator/SingleValidator';
 import ClickedBtn from '@/components/Button/ClickedBtn';
 import useAuth from '@/hooks/useAuth';
 import axios from 'axios';
-import useModal from '@/hooks/useModal';
-import { createPortal } from 'react-dom';
 import RiseUpModal from '@/components/Modal/RiseUpModal';
 import { ModalType } from '@/types/modal/riseUp';
 import { useAtom } from 'jotai';
@@ -104,7 +102,7 @@ function ProfileModify({ modalHandler }: { modalHandler: () => void }) {
     overlay.open(({ unmount }) => {
       return (
         <RiseUpModal
-          modalType="keyword"
+          modalType="field"
           modalHandler={() => {
             unmount();
           }}

--- a/src/components/Content/SInfoModify/SInfoModify.tsx
+++ b/src/components/Content/SInfoModify/SInfoModify.tsx
@@ -7,7 +7,6 @@ import {
   ValidatorBox,
 } from './SInfoModify.styled';
 import x_icon from '../../../../public/x.png';
-import user_icon from '../../../../public/user.png';
 import camera_icon from '../../../../public/camera.png';
 import Image from 'next/image';
 import RoundedImage from '@/components/Image/RoundedImage';
@@ -15,13 +14,8 @@ import NicknameForm from '@/components/SingleForm/NicknameForm';
 import PhoneNumForm from '@/components/SingleForm/PhoneNumForm';
 import { useEffect, useRef, useState } from 'react';
 import SingleValidator from '@/components/Validator/SingleValidator';
-import ClickedBtn from '@/components/Button/ClickedBtn';
 import useAuth from '@/hooks/useAuth';
 import axios from 'axios';
-import {
-  StaticImageData,
-  StaticImport,
-} from 'next/dist/shared/lib/get-img-props';
 import { useAtom, useAtomValue } from 'jotai';
 import {
   changeNickname,
@@ -36,12 +30,8 @@ import ModalBtn from '@/components/Button/ModalBtn';
 import { bankNameAtom } from '@/stores/bankName';
 import { overlay } from 'overlay-kit';
 import { ModalType } from '@/types/modal/riseUp';
-import useModal from '@/hooks/useModal';
 import RiseUpModal from '@/components/Modal/RiseUpModal';
-import { createPortal } from 'react-dom';
-import { useRouter } from 'next/navigation';
 import findExCode from '@/utils/findExCode';
-import useFullModal from '@/hooks/useFullModal';
 
 function SInfoModify({
   modalHandler,
@@ -266,11 +256,17 @@ function SInfoModify({
             btnText={bank ? bank : '\u00A0\u00A0\u00A0\u00A0'}
             modalHandler={bModalHandler}
             onClick={() => {
-              overlay.open(({ unmount }) => {
-                return <RiseUpModal modalHandler={unmount} modalType="bank" />;
-              });
-              bModalHandler();
               setModalType('bank');
+              overlay.open(({ unmount, close }) => {
+                return (
+                  <RiseUpModal
+                    modalHandler={() => {
+                      unmount();
+                    }}
+                    modalType="bank"
+                  />
+                );
+              });
             }}
           />
         </div>

--- a/src/components/Content/SInfoModify/SInfoModify.tsx
+++ b/src/components/Content/SInfoModify/SInfoModify.tsx
@@ -34,12 +34,14 @@ import {
 import NextBtn from '@/components/Button/NextBtn';
 import ModalBtn from '@/components/Button/ModalBtn';
 import { bankNameAtom } from '@/stores/bankName';
+import { overlay } from 'overlay-kit';
 import { ModalType } from '@/types/modal/riseUp';
 import useModal from '@/hooks/useModal';
 import RiseUpModal from '@/components/Modal/RiseUpModal';
 import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import findExCode from '@/utils/findExCode';
+import useFullModal from '@/hooks/useFullModal';
 
 function SInfoModify({
   modalHandler,
@@ -48,13 +50,8 @@ function SInfoModify({
   bModalHandler: () => void;
   modalHandler: () => void;
 }) {
-  const router = useRouter();
   const [flag, setFlag] = useState(false);
-  const {
-    modal: BModal,
-    modalHandler: BModalHandler,
-    portalElement: BPotalElement,
-  } = useModal('senior-info-portal');
+
   const [modalType, setModalType] = useState<ModalType>('bank');
   const [submitFlag, setSubmitFlag] = useState(false);
   const [accHolder, setAccHolder] = useState('');
@@ -269,6 +266,10 @@ function SInfoModify({
             btnText={bank ? bank : '\u00A0\u00A0\u00A0\u00A0'}
             modalHandler={bModalHandler}
             onClick={() => {
+              overlay.open(({ unmount }) => {
+                return <RiseUpModal modalHandler={unmount} modalType="bank" />;
+              });
+              bModalHandler();
               setModalType('bank');
             }}
           />

--- a/src/components/Content/SInfoModify/SInfoModify.tsx
+++ b/src/components/Content/SInfoModify/SInfoModify.tsx
@@ -261,6 +261,7 @@ function SInfoModify({
                 return (
                   <RiseUpModal
                     modalHandler={() => {
+                      close();
                       unmount();
                     }}
                     modalType="bank"

--- a/src/components/Modal/FullModal/FullModal.tsx
+++ b/src/components/Modal/FullModal/FullModal.tsx
@@ -12,69 +12,67 @@ import SelectCalendar from '@/components/Content/SelectCalendar';
 import { firAbleTimeAtom } from '@/stores/mentoring';
 import MentoringSpec from '@/components/Mentoring/MentoringSpec/JmentoringSpec';
 import AccountReactivation from '@/components/Content/AccountReactivation';
+
 function FullModal(props: FullModalProps) {
   return (
-    <>
-      <FullModalContainer>
-        {props.modalType == 'best-case' && (
-          <MBestCaseContent modalHandler={props.modalHandler} />
-        )}
-        {props.modalType === 'account-reactive' && (
-          <AccountReactivation
-            onActive={props.modalHandler}
-            onNonActive={props.cancelModalHandler}
-          />
-        )}
-        {props.modalType == 'login-request' && (
-          <MyLoginRequest modalHandler={props.modalHandler} />
-        )}
-        {props.modalType == 'senior-my-profile' && (
-          <SeniorMyProfile modalHandler={props.modalHandler} />
-        )}
-        {props.modalType == 'junior-mentoring-spec' && (
-          <MentoringSpec
-            modalHandler={props.modalHandler}
-            cancelModalHandler={
-              props.cancelModalHandler ? props.cancelModalHandler : () => {}
-            }
-            mentoringId={props.mentoringId ? props.mentoringId : 0}
-          />
-        )}
-        {props.modalType == 'profile-modify' && (
-          <ProfileModify modalHandler={props.modalHandler} />
-        )}
-        {props.modalType == 'accept-mentoring' && (
-          <SmentoringAccept modalHandler={props.modalHandler} />
-        )}
-        {props.modalType == 'senior-info-modify' && (
-          <SInfoModify
-            bModalHandler={props.bModalHandler ? props.bModalHandler : () => {}}
-            modalHandler={props.modalHandler}
-          />
-        )}
-        {props.modalType == 'senior-mentoring-time' && (
-          <AddTime modalHandler={props.modalHandler} />
-        )}
-        {props.modalType == 'senior-mentoring-spec' && (
-          <SmentoringSpec
-            cancelModalHandler={
-              props.cancelModalHandler ? props.cancelModalHandler : () => {}
-            }
-            modalHandler={props.modalHandler}
-            acceptModalHandler={
-              props.acceptModalHandler ? props.acceptModalHandler : () => {}
-            }
-            mentoringId={props.mentoringId ? props.mentoringId : 0}
-          />
-        )}
-        {props.modalType == 'select-date-calendar' && (
-          <SelectCalendar
-            modalHandler={props.modalHandler}
-            targetAtom={props.targetAtom || firAbleTimeAtom}
-          />
-        )}
-      </FullModalContainer>
-    </>
+    <FullModalContainer>
+      {(() => {
+        switch (props.modalType) {
+          case 'best-case':
+            return <MBestCaseContent modalHandler={props.modalHandler} />;
+          case 'account-reactive':
+            return (
+              <AccountReactivation
+                onActive={props.modalHandler}
+                onNonActive={props.cancelModalHandler}
+              />
+            );
+          case 'login-request':
+            return <MyLoginRequest modalHandler={props.modalHandler} />;
+          case 'senior-my-profile':
+            return <SeniorMyProfile modalHandler={props.modalHandler} />;
+          case 'junior-mentoring-spec':
+            return (
+              <MentoringSpec
+                modalHandler={props.modalHandler}
+                cancelModalHandler={props.cancelModalHandler || (() => {})}
+                mentoringId={props.mentoringId || 0}
+              />
+            );
+          case 'profile-modify':
+            return <ProfileModify modalHandler={props.modalHandler} />;
+          case 'accept-mentoring':
+            return <SmentoringAccept modalHandler={props.modalHandler} />;
+          case 'senior-info-modify':
+            return (
+              <SInfoModify
+                bModalHandler={props.bModalHandler || (() => {})}
+                modalHandler={props.modalHandler}
+              />
+            );
+          case 'senior-mentoring-time':
+            return <AddTime modalHandler={props.modalHandler} />;
+          case 'senior-mentoring-spec':
+            return (
+              <SmentoringSpec
+                cancelModalHandler={props.cancelModalHandler || (() => {})}
+                modalHandler={props.modalHandler}
+                acceptModalHandler={props.acceptModalHandler || (() => {})}
+                mentoringId={props.mentoringId || 0}
+              />
+            );
+          case 'select-date-calendar':
+            return (
+              <SelectCalendar
+                modalHandler={props.modalHandler}
+                targetAtom={props.targetAtom || firAbleTimeAtom}
+              />
+            );
+          default:
+            return null;
+        }
+      })()}
+    </FullModalContainer>
   );
 }
 

--- a/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
+++ b/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
@@ -7,7 +7,7 @@ export const ModalBackground = styled.div`
   transform: translateY(-50%);
   width: 360px;
   height: 100vh;
-  z-index: 2;
+  z-index: 0;
 
   @keyframes modalAppear {
     from {

--- a/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
+++ b/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
@@ -7,7 +7,6 @@ export const ModalBackground = styled.div`
   transform: translateY(-50%);
   width: 360px;
   height: 100vh;
-  z-index: 0;
 
   @keyframes modalAppear {
     from {

--- a/src/components/Modal/SearchModal/SearchModal.tsx
+++ b/src/components/Modal/SearchModal/SearchModal.tsx
@@ -8,7 +8,7 @@ export default function SearchModal(props: SearchModalProps) {
   const ModalClick = () => {
     props.modalHandler();
   };
-  console.log(props.modalHandler);
+
   return (
     <SearchModalBgBox onClick={ModalClick}>
       <SearchModalInput onClick={(e) => e.stopPropagation()}>

--- a/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
+++ b/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
@@ -1,27 +1,20 @@
 import {
-  SeniorManageAuthBox,
   SeniorManageContainer,
   SeniorManageContentContainer,
-  SeniorManageAuthValue,
 } from './SeniorManage.styled';
 import ContentComponent from '../../Box/ContentBox';
 import TitleComponent from '../../Box/TitleBox';
 import { SeniorManageProps } from '@/types/profile/seniorManage';
-import { certiRegType } from '@/types/profile/profile';
+
 import useModal from '@/hooks/useModal';
 import { createPortal } from 'react-dom';
-import FullModal from '@/components/Modal/FullModal';
-import DimmedModal from '@/components/Modal/DimmedModal';
 import Router, { useRouter } from 'next/navigation';
-import { mySeniorId } from '@/stores/senior';
 import useAuth from '@/hooks/useAuth';
 import axios from 'axios';
-import { userType } from '@/types/user/user';
 import { socialIdAtom, userTypeAtom } from '@/stores/signup';
 import { useAtom, useSetAtom } from 'jotai';
 import findExCode from '@/utils/findExCode';
 import useFullModal from '@/hooks/useFullModal';
-import { useEffect } from 'react';
 function SeniorManage(props: SeniorManageProps) {
   const router = useRouter();
   const {
@@ -37,12 +30,11 @@ function SeniorManage(props: SeniorManageProps) {
 
   const { openModal: _openSeniorMyProfileModal } = useFullModal({
     modalType: 'senior-my-profile',
-    modalHandler: () => {},
   });
 
   const { openModal: openSeniorInfoModifyModal } = useFullModal({
     modalType: 'senior-info-modify',
-    modalHandler: () => {},
+    bModalHandler: props.modalHandler,
   });
 
   const {

--- a/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
+++ b/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
@@ -15,6 +15,7 @@ import { socialIdAtom, userTypeAtom } from '@/stores/signup';
 import { useAtom, useSetAtom } from 'jotai';
 import findExCode from '@/utils/findExCode';
 import useFullModal from '@/hooks/useFullModal';
+import DimmedModal from '@/components/Modal/DimmedModal';
 function SeniorManage(props: SeniorManageProps) {
   const router = useRouter();
   const {

--- a/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
+++ b/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
@@ -19,8 +19,9 @@ import axios from 'axios';
 import { userType } from '@/types/user/user';
 import { socialIdAtom, userTypeAtom } from '@/stores/signup';
 import { useAtom, useSetAtom } from 'jotai';
-import { useEffect } from 'react';
 import findExCode from '@/utils/findExCode';
+import useFullModal from '@/hooks/useFullModal';
+import { useEffect } from 'react';
 function SeniorManage(props: SeniorManageProps) {
   const router = useRouter();
   const {
@@ -30,26 +31,26 @@ function SeniorManage(props: SeniorManageProps) {
     setRefreshToken,
     removeTokens,
   } = useAuth();
-  const { modal, modalHandler, portalElement } = useModal(
-    'senior-my-profile-portal',
-  );
+
   const [socialId, setSocialId] = useAtom(socialIdAtom);
   const setuserTypeAtom = useSetAtom(userTypeAtom);
-  const {
-    modal: modifyModal,
-    modalHandler: modifyHandler,
-    portalElement: modifyPortal,
-  } = useModal('profile-modify-portal');
+
+  const { openModal: _openSeniorMyProfileModal } = useFullModal({
+    modalType: 'senior-my-profile',
+    modalHandler: () => {},
+  });
+
+  const { openModal: openSeniorInfoModifyModal } = useFullModal({
+    modalType: 'senior-info-modify',
+    modalHandler: () => {},
+  });
+
   const {
     modal: setJModal,
     modalHandler: juniorHandler,
     portalElement: juniorPortal,
   } = useModal('junior-request-portal');
-  const {
-    modal: infoModal,
-    modalHandler: infoHandler,
-    portalElement: infoPortal,
-  } = useModal('senior-info-modify-portal');
+
   const {
     modal: registerModal,
     modalHandler: registerHandler,
@@ -167,7 +168,10 @@ function SeniorManage(props: SeniorManageProps) {
     <SeniorManageContainer>
       <SeniorManageContentContainer>
         <TitleComponent title="계정 관리" />
-        <ContentComponent content="계정 설정" onClick={infoHandler} />
+        <ContentComponent
+          content="계정 설정"
+          onClick={openSeniorInfoModifyModal}
+        />
         <ContentComponent content="내 프로필 보기" onClick={MyprofHandler} />
 
         <ContentComponent
@@ -195,34 +199,7 @@ function SeniorManage(props: SeniorManageProps) {
           onClick={changeJunior}
         />
       </SeniorManageContentContainer>
-      {modal && portalElement
-        ? createPortal(
-            <FullModal
-              modalType="senior-my-profile"
-              modalHandler={modalHandler}
-            />,
-            portalElement,
-          )
-        : null}
-      {modifyModal && modifyPortal
-        ? createPortal(
-            <FullModal
-              modalType="profile-modify"
-              modalHandler={modifyHandler}
-            />,
-            modifyPortal,
-          )
-        : null}
-      {infoModal && infoPortal
-        ? createPortal(
-            <FullModal
-              modalType="senior-info-modify"
-              modalHandler={infoHandler}
-              bModalHandler={props.modalHandler}
-            />,
-            infoPortal,
-          )
-        : null}
+
       {registerModal && registerPortal
         ? createPortal(
             <DimmedModal

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -17,7 +17,6 @@ function Scheduler() {
 
   const { openModal: openSeniorMentoringTimeModal } = useFullModal({
     modalType: 'senior-mentoring-time',
-    modalHandler: () => {},
   });
   const clickHandler = (removeIdx: number) => {
     setTimeData(timeData.filter((_, idx) => idx !== removeIdx));

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -1,4 +1,3 @@
-import { SchedulerProps, TimeObj } from '@/types/scheduler/scheduler';
 import {
   SchedulerContainer,
   SchedulerEl,
@@ -8,18 +7,18 @@ import {
   SchedulerBox,
 } from './Scheduler.styled';
 import { PROFILE_SUB_DIRECTION } from '@/constants/form/cProfileForm';
-import React, { useEffect, useState } from 'react';
-import useModal from '@/hooks/useModal';
-import { createPortal } from 'react-dom';
-import FullModal from '../Modal/FullModal';
+import React from 'react';
+import useFullModal from '@/hooks/useFullModal';
 import { useAtom } from 'jotai';
 import { sAbleTime } from '@/stores/senior';
 
 function Scheduler() {
   const [timeData, setTimeData] = useAtom(sAbleTime);
-  const { modal, modalHandler, portalElement } = useModal(
-    'senior-mentoring-time-portal',
-  );
+
+  const { openModal: openSeniorMentoringTimeModal } = useFullModal({
+    modalType: 'senior-mentoring-time',
+    modalHandler: () => {},
+  });
   const clickHandler = (removeIdx: number) => {
     setTimeData(timeData.filter((_, idx) => idx !== removeIdx));
   };
@@ -37,7 +36,9 @@ function Scheduler() {
               <div id="add-time-empty" style={{ marginBottom: '1.25rem' }}>
                 {PROFILE_SUB_DIRECTION.addTimeEmpty}
               </div>
-              <SCHAddBtn onClick={modalHandler}>+추가하기</SCHAddBtn>
+              <SCHAddBtn onClick={openSeniorMentoringTimeModal}>
+                +추가하기
+              </SCHAddBtn>
             </SchedulerEmptyBox>
           </SchedulerBox>
         ) : (
@@ -64,18 +65,11 @@ function Scheduler() {
                 </SchedulerEl>
               ))}
             </SchedulerElContainer>
-            <SCHAddBtn onClick={modalHandler}>+추가하기</SCHAddBtn>
+            <SCHAddBtn onClick={openSeniorMentoringTimeModal}>
+              +추가하기
+            </SCHAddBtn>
           </div>
         )}
-        {modal && portalElement
-          ? createPortal(
-              <FullModal
-                modalType="senior-mentoring-time"
-                modalHandler={modalHandler}
-              />,
-              portalElement,
-            )
-          : ''}
       </SchedulerContainer>
     </div>
   );

--- a/src/components/SelectTime/SelectTime.tsx
+++ b/src/components/SelectTime/SelectTime.tsx
@@ -8,19 +8,19 @@ import {
 } from './SelectTime.styled';
 import Image from 'next/image';
 import down_arrow from '../../../public/arrow-down.png';
-import useModal from '@/hooks/useModal';
-import { createPortal } from 'react-dom';
-import FullModal from '../Modal/FullModal';
 import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
 import { MENTORING_SCHEDULE } from '@/constants/form/cMentoringApply';
+import useFullModal from '@/hooks/useFullModal';
 
 function SelectTime(props: SelectTimeProps) {
   const targetAtomValue = useAtomValue(props.targetAtom);
   const [thisFlag, setThisFlag] = useState(false);
-  const { modal, modalHandler, portalElement } = useModal(
-    'select-date-calendar',
-  );
+
+  const { openModal: openSelectDateCalendarModal } = useFullModal({
+    modalType: 'select-date-calendar',
+    modalHandler: () => {},
+  });
   const [inputValue, setInputValue] = useState(
     `${props.numStr}${MENTORING_SCHEDULE.selectPlaceholder}`,
   );
@@ -60,21 +60,14 @@ function SelectTime(props: SelectTimeProps) {
 
   return (
     <SelectTimeWrapper>
-      <SelectTimeContainer onClick={modalHandler} $alertFlag={thisFlag}>
+      <SelectTimeContainer
+        onClick={openSelectDateCalendarModal}
+        $alertFlag={thisFlag}
+      >
         <SelectTimeContent>
           <SelectTimeText className="disabled">{inputValue}</SelectTimeText>
           <Image id="down-arrow" src={down_arrow} alt="아래 화살표" />
         </SelectTimeContent>
-        {modal && portalElement
-          ? createPortal(
-              <FullModal
-                modalType="select-date-calendar"
-                modalHandler={modalHandler}
-                targetAtom={props.targetAtom}
-              />,
-              portalElement,
-            )
-          : null}
       </SelectTimeContainer>
       {thisFlag && (
         <SelectTimeValidator>일정이 선택되지 않았습니다.</SelectTimeValidator>

--- a/src/components/SelectTime/SelectTime.tsx
+++ b/src/components/SelectTime/SelectTime.tsx
@@ -19,7 +19,7 @@ function SelectTime(props: SelectTimeProps) {
 
   const { openModal: openSelectDateCalendarModal } = useFullModal({
     modalType: 'select-date-calendar',
-    modalHandler: () => {},
+    targetAtom: props.targetAtom,
   });
   const [inputValue, setInputValue] = useState(
     `${props.numStr}${MENTORING_SCHEDULE.selectPlaceholder}`,

--- a/src/components/SingleForm/BankForm/BankForm.tsx
+++ b/src/components/SingleForm/BankForm/BankForm.tsx
@@ -43,12 +43,12 @@ function BankForm({ clickHandler }: { clickHandler: () => void }) {
   const [bank, setBank] = useAtom(bankNameAtom);
 
   const handleClick = (selectedBank: string) => {
-    setBank(selectedBank);
     clickHandler();
+    setBank(selectedBank);
   };
 
   return (
-    <BankContent onClick={clickHandler}>
+    <BankContent>
       <div style={{ display: 'flex' }}>
         <h3>은행선택</h3>
         <Image

--- a/src/components/SingleForm/BankForm/BankForm.tsx
+++ b/src/components/SingleForm/BankForm/BankForm.tsx
@@ -48,11 +48,13 @@ function BankForm({ clickHandler }: { clickHandler: () => void }) {
   };
 
   return (
-    <BankContent>
+    <BankContent onClick={clickHandler}>
       <div style={{ display: 'flex' }}>
         <h3>은행선택</h3>
         <Image
-          onClick={clickHandler}
+          onClick={(e) => {
+            clickHandler();
+          }}
           src={x_btn}
           alt="x_btn"
           width={21}

--- a/src/hooks/useFullModal.tsx
+++ b/src/hooks/useFullModal.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 interface UseFullModalProps extends FullModalProps {
   overlayId?: string;
 }
-const useFullModal = ({ ...props }: UseFullModalProps) => {
+const useFullModal = ({ ...props }: Partial<UseFullModalProps>) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const openModal = () => {
@@ -16,7 +16,7 @@ const useFullModal = ({ ...props }: UseFullModalProps) => {
         return (
           <FullModal
             {...props}
-            modalType={props.modalType}
+            modalType={props?.modalType ?? 'best-case'}
             modalHandler={() => {
               if (props.modalHandler) {
                 props.modalHandler();

--- a/src/hooks/useFullModal.tsx
+++ b/src/hooks/useFullModal.tsx
@@ -1,0 +1,57 @@
+import FullModal from '@/components/Modal/FullModal';
+import { FullModalProps } from '@/types/modal/full';
+import { overlay } from 'overlay-kit';
+import { useState } from 'react';
+
+interface UseFullModalProps extends FullModalProps {
+  overlayId?: string;
+}
+const useFullModal = ({ ...props }: UseFullModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+    overlay.open(
+      ({ unmount }) => {
+        return (
+          <FullModal
+            {...props}
+            modalType={props.modalType}
+            modalHandler={() => {
+              if (props.modalHandler) {
+                props.modalHandler();
+              }
+              closeModal(unmount);
+            }}
+            cancelModalHandler={() => {
+              if (props.cancelModalHandler) {
+                props.cancelModalHandler();
+              }
+              closeModal(unmount);
+            }}
+          />
+        );
+      },
+      {
+        overlayId: props.overlayId ?? '',
+      },
+    );
+  };
+
+  const closeModal = (unmount: () => void) => {
+    setIsOpen(false);
+    unmount();
+  };
+
+  const toggleModal = () => {
+    if (isOpen) {
+      closeModal(() => {});
+    } else {
+      openModal();
+    }
+  };
+
+  return { openModal, closeModal, toggleModal, isOpen };
+};
+
+export default useFullModal;

--- a/src/types/modal/full.ts
+++ b/src/types/modal/full.ts
@@ -1,21 +1,23 @@
 import { PrimitiveAtom } from 'jotai';
 
 /** FullModal로 띄울 컨텐츠 새로 구현할 때마다 타입으로 추가 */
-export type FullModalType =
-  | 'best-case'
-  | 'login-request'
-  | 'senior-my-profile'
-  | 'profile-modify'
-  | 'accept-mentoring'
-  | 'senior-info-modify'
-  | 'senior-mentoring-time'
-  | 'senior-mentoring-spec'
-  | 'select-date-calendar'
-  | 'junior-mentoring-spec'
-  | 'account-reactive';
 
-export interface FullModalProps {
-  modalType: FullModalType;
+export interface FullModalType {
+  modalType:
+    | 'best-case'
+    | 'login-request'
+    | 'senior-my-profile'
+    | 'profile-modify'
+    | 'accept-mentoring'
+    | 'senior-info-modify'
+    | 'senior-mentoring-time'
+    | 'senior-mentoring-spec'
+    | 'select-date-calendar'
+    | 'junior-mentoring-spec'
+    | 'account-reactive';
+}
+
+export interface FullModalProps extends FullModalType {
   modalHandler: () => void;
   bModalHandler?: () => void;
   selectedMentoringId?: number;


### PR DESCRIPTION
## 🦝 PR 요약

여러 portal로 관리하고 있는 모달들을 `overlay-kit`로 관리하게 수정하였습니다.

## ✨ PR 상세 내용

지금은 아래처럼 모달 하나마다 `createPortal`로 모달을 열고 이것을 관리해주고 있습니당.

```html
<div id = "some-modal-id"></div>
```

createPortal을 줄여주고 모달을 잘 관리하기 위해 `overlay-kit`를 사용했습니다. 
번들 크기도 적고, 여러곳에 흩뿌려진 모달을 하나하나 줄여나가고 있는 중인데, 서비스에 걸쳐 사용되는 모달이 크게 3개더라구요

`FullModal` , `RiseUpModal` , `DimmendModal` 요 3개인데, 이 3개에 모두 적용되게끔 하는 훅을 만들어보고자 하였으나,, 각각의 모달마다 받는 `modalType`을 어떻게 관리해야 할지 몰라서, 일단 `FullModal`만 적용되는 훅을 만들었습니다.

(useFullModal 훅만 보면 됩니다..)

아래처럼 `createPortal`을 만들고 modalHandler를 사용하는 것에서 벗어나 아래의 훅을 만들었어요.

```tsx
import FullModal from '@/components/Modal/FullModal';
import { FullModalProps } from '@/types/modal/full';
import { overlay } from 'overlay-kit';
import { useState } from 'react';

interface UseFullModalProps extends FullModalProps {
  overlayId?: string;
}
const useFullModal = ({ ...props }: Partial<UseFullModalProps>) => {
  const [isOpen, setIsOpen] = useState(false);

  const openModal = () => {
    setIsOpen(true);
    overlay.open(
      ({ unmount }) => {
        return (
          <FullModal
            {...props}
            modalType={props?.modalType ?? 'best-case'}
            modalHandler={() => {
              if (props.modalHandler) {
                props.modalHandler();
              }
              closeModal(unmount);
            }}
            cancelModalHandler={() => {
              if (props.cancelModalHandler) {
                props.cancelModalHandler();
              }
              closeModal(unmount);
            }}
          />
        );
      },
      {
        overlayId: props.overlayId ?? '',
      },
    );
  };

  const closeModal = (unmount: () => void) => {
    setIsOpen(false);
    unmount();
  };

  const toggleModal = () => {
    if (isOpen) {
      closeModal(() => {});
    } else {
      openModal();
    }
  };

  return { openModal, closeModal, toggleModal, isOpen };
};

export default useFullModal;
```

다만 `FullModal`안에서 `RiseUpModal`을 호출하는 경우 문제가 있었는데, z-index값을 일단 조절해서 임시로 해결했습니다.

최종 목적은 지금 id로 등록되어 관리하고 있는 모달들을 모두 제거하는 ..것입니다!


## 🚨 주의 사항

지금처럼 형태가 다른 3개의 모달(RiseUp,FullModal,DimmendModal)을 모두 커버 가능하게 관리하려면 어떻게 해야 할까요..?


## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
