### PR TITLE
RAC-434 Refactor: 재가입 API axios 인스턴스 안거치게 적용

### DIFF
--- a/src/api/auth/rejoin/rejoinPatchFetch.ts
+++ b/src/api/auth/rejoin/rejoinPatchFetch.ts
@@ -1,5 +1,5 @@
-import instance from '@/api/api';
 import { KakaoAuthFetchResponse } from '@/api/auth/login/kakaoAuthFetch';
+import axios from 'axios';
 
 interface RejoinFetchRequest {
   socialId: string;
@@ -10,8 +10,11 @@ export const rejoinPatchFetch = async ({
   socialId,
   rejoin,
 }: RejoinFetchRequest) => {
-  return await instance.patch<KakaoAuthFetchResponse>('/auth/rejoin/KAKAO', {
-    socialId,
-    rejoin,
-  });
+  return await axios.patch<KakaoAuthFetchResponse>(
+    `${process.env.NEXT_PUBLIC_SERVER_URL}/auth/rejoin/KAKAO`,
+    {
+      socialId,
+      rejoin,
+    },
+  );
 };

--- a/src/components/Modal/RiseUpModal/RiseUpModal.tsx
+++ b/src/components/Modal/RiseUpModal/RiseUpModal.tsx
@@ -4,9 +4,6 @@ import SearchForm from '@/components/SingleForm/SearchForm';
 import SelectForm from '@/components/SingleForm/SelectForm';
 import KeywordForm from '@/components/SingleForm/KeywordForm/KeywordForm';
 import BankForm from '@/components/SingleForm/BankForm';
-import { useForm, FormProvider } from 'react-hook-form';
-import { editProfileSchema } from '@/app/senior/edit-profile/edit-profile-schema';
-import { yupResolver } from '@hookform/resolvers/yup';
 
 function RiseUpModal(props: RiseUpModalProps) {
   return (

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -27,7 +27,7 @@ const useKakaoLogin = () => {
       isTutorial,
       refreshExpiration,
       socialId,
-    } = userRes.data;
+    } = userRes?.data;
 
     setAccessToken({ token: accessToken, expires: accessExpiration });
     setRefreshToken({ token: refreshToken, expires: refreshExpiration });
@@ -50,7 +50,7 @@ const useKakaoLogin = () => {
 
         if (kakaoAuthFetchRes.code === 'AU204') {
           setUserContext(kakaoAuthFetchRes);
-          router.replace('/');
+          router.push('/');
           return;
         }
 
@@ -63,8 +63,14 @@ const useKakaoLogin = () => {
                   const res = await rejoinPatchFetch({
                     socialId,
                     rejoin: true,
+                  }).then((res) => {
+                    if (res.data.code === 'EX300') {
+                      router.push('/');
+                    }
+                    setUserContext(res.data);
+                    router.push('/');
+                    unmount();
                   });
-                  setUserContext(res.data);
                 }}
                 cancelModalHandler={async () => {
                   await rejoinPatchFetch({ socialId, rejoin: false }).then(

--- a/src/hooks/useSEdit.ts
+++ b/src/hooks/useSEdit.ts
@@ -18,8 +18,6 @@ import { useAtom } from 'jotai';
 import { seniorProfileFetch } from '@/api/user/profile/getSeniorProfile';
 import { useRouter } from 'next/navigation';
 import { updateSeniorProfile } from '@/api/user/profile/updateSeniorProfile';
-import { UseFormSetValue, UseFormTrigger } from 'react-hook-form';
-import { editProfileSchema } from '@/app/senior/edit-profile/edit-profile-schema';
 
 const useSEdit = () => {
   const [allFieldValid, setAllFieldValid] = useState(false);


### PR DESCRIPTION
## 🦝 PR 요약

재가입 API요청 기존 인스턴스 안거치게 적용

## ✨ PR 상세 내용

탈퇴는 정상적으로 되지만 재가입 요청이 아예 전송되지 않는 문제가 있었습니다.
기존 재가입 API는 `axios 인스턴스`를 통해 요청을 보내고 있었는데, `인스턴스의 인터셉터`에서 토큰이 없는 경우, 바로 홈으로 라우팅을 시켜버려서 , 아예 재가입 요청이 안가는 문제가 있었습니다.

따라서 `재가입 요청`의 경우 `인스턴스`를 사용하지 않고 요청을 보내게 수정하였습니다!

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
