### PR TITLE
RAC-441 Refactor: DimmedModal portal -> useDimmedModal로 리팩토링

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,6 @@ export default function RootLayout({
             <OverlayKitProvider>
               {children}
               <div id="junior-mentoring-cancel"></div>
-              <div id="senior-profile-portal"></div>
               <div id="senior-request-portal"></div>
               <div id="junior-request-portal"></div>
               <div id="senior-mentoring-cancel"></div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,8 +37,6 @@ export default function RootLayout({
               <div id="senior-profile-not-registered"></div>
               <div id="suggest-mypage-portal"></div>
               <div id="senior-auth-portal"></div>
-              <div id="mentoring-login-portal"></div>
-              <div id="change-junior-portal"></div>
               <div id=" mentoring-cancel-success"></div>
             </OverlayKitProvider>
           </StyledComponentsRegistry>
@@ -47,4 +45,3 @@ export default function RootLayout({
     </html>
   );
 }
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,9 +31,7 @@ export default function RootLayout({
               {children}
               <div id="junior-mentoring-cancel"></div>
               <div id="senior-request-portal"></div>
-              <div id="junior-request-portal"></div>
               <div id="senior-mentoring-cancel"></div>
-              <div id="senior-profile-not-registered"></div>
               <div id="suggest-mypage-portal"></div>
               <div id="senior-auth-portal"></div>
               <div id=" mentoring-cancel-success"></div>

--- a/src/app/senior/info/[seniorId]/page.tsx
+++ b/src/app/senior/info/[seniorId]/page.tsx
@@ -3,9 +3,7 @@ import IntroCard from '@/components/Card/IntroCard';
 import KeywordCard from '@/components/Card/KeywordCard';
 import ProfileCard from '@/components/Card/ProfileCard';
 import BackHeader from '@/components/Header/BackHeader';
-import DimmedModal from '@/components/Modal/DimmedModal';
 import useAuth from '@/hooks/useAuth';
-import useModal from '@/hooks/useModal';
 import {
   firAbleTimeAtom,
   questionAtom,
@@ -19,8 +17,9 @@ import axios from 'axios';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
 import styled from 'styled-components';
+
+import useDimmedModal from '@/hooks/useDimmedModal';
 
 function SeniorInfoPage() {
   const router = useRouter();
@@ -51,14 +50,10 @@ function SeniorInfoPage() {
   const setSecAbleTime = useSetAtom(secAbleTimeAtom);
   const setThiAbleTime = useSetAtom(thiAbleTimeAtom);
   const [certification, setCertification] = useState(Boolean);
-  const { modal, modalHandler, portalElement } = useModal(
-    'mentoring-login-portal',
-  );
-  const {
-    modal: cjModal,
-    modalHandler: cjModalHandler,
-    portalElement: cjPortalEl,
-  } = useModal('change-junior-portal');
+
+  const { openModal: openChangeJuniorModal } = useDimmedModal({
+    modalType: 'changeJunior',
+  });
 
   useEffect(() => {
     setTempSubject('');
@@ -67,6 +62,10 @@ function SeniorInfoPage() {
     setSecAbleTime('');
     setThiAbleTime('');
   }, []);
+
+  const { openModal: openMentoringNotLoginModal } = useDimmedModal({
+    modalType: 'mentoringLogin',
+  });
 
   useEffect(() => {
     const totalWidth =
@@ -131,11 +130,11 @@ function SeniorInfoPage() {
 
         if (userType == 'senior') {
           // 후배 회원 전환 요청 모달 출현
-          cjModalHandler();
+          openChangeJuniorModal();
         }
       } else {
         // 로그인 요청 모달 출현
-        modalHandler();
+        openMentoringNotLoginModal();
       }
     });
   };
@@ -182,24 +181,6 @@ function SeniorInfoPage() {
           </MentoringApplyBtn>
         </>
       )}
-      {modal && portalElement
-        ? createPortal(
-            <DimmedModal
-              modalType="mentoringLogin"
-              modalHandler={modalHandler}
-            />,
-            portalElement,
-          )
-        : ''}
-      {cjModal && cjPortalEl
-        ? createPortal(
-            <DimmedModal
-              modalType="changeJunior"
-              modalHandler={cjModalHandler}
-            />,
-            cjPortalEl,
-          )
-        : ''}
     </SeniorInfoPageContainer>
   );
 }

--- a/src/app/signup/done/page.tsx
+++ b/src/app/signup/done/page.tsx
@@ -5,9 +5,6 @@ import { useAtomValue } from 'jotai';
 import Image from 'next/image';
 import party_popper from '../../../../public/party_popper.png';
 import ClickedBtn from '@/components/Button/ClickedBtn';
-import useModal from '@/hooks/useModal';
-import { createPortal } from 'react-dom';
-import DimmedModal from '@/components/Modal/DimmedModal';
 import { useRouter } from 'next/navigation';
 import BackHeader from '@/components/Header/BackHeader';
 import styled from 'styled-components';
@@ -19,9 +16,6 @@ function SignUpDonePage() {
   const prevPath = useAtomValue(prevPathAtom);
   const { getUserType } = useAuth();
   const [userType, setUserType] = useState('');
-  const { modal, modalHandler, portalElement } = useModal(
-    'senior-profile-portal',
-  );
 
   useEffect(() => {
     const userT = getUserType();
@@ -104,15 +98,6 @@ function SignUpDonePage() {
           </div>
         </>
       )}
-      {modal && portalElement
-        ? createPortal(
-            <DimmedModal
-              modalType="postgraduProfile"
-              modalHandler={modalHandler}
-            />,
-            portalElement,
-          )
-        : null}
     </div>
   );
 }

--- a/src/components/Content/ChangeJunior/ChangeJunior.tsx
+++ b/src/components/Content/ChangeJunior/ChangeJunior.tsx
@@ -9,6 +9,7 @@ function ChangeJunior({ modalHandler }: { modalHandler: () => void }) {
 
   const handleClick = () => {
     router.push('/mypage');
+    modalHandler();
   };
 
   return (

--- a/src/components/Content/PayAmount/PayAmount.tsx
+++ b/src/components/Content/PayAmount/PayAmount.tsx
@@ -20,6 +20,7 @@ function PayAmount({ modalHandler }: { modalHandler: () => void }) {
 
   const nextClick = () => {
     router.push(`/mentoring-apply/${seniorId}/schedule`);
+    modalHandler();
   };
 
   return (

--- a/src/components/Content/SNotRegistered/SNotRegistered.tsx
+++ b/src/components/Content/SNotRegistered/SNotRegistered.tsx
@@ -20,6 +20,7 @@ function SNotRegistered({ modalHandler }: { modalHandler: () => void }) {
       <PNRBtn
         onClick={() => {
           router.push('/add-profile');
+          modalHandler();
         }}
       >
         {PROFILE_NOT_REGISTERED.btnText}

--- a/src/components/NotJunior/NotJunior.tsx
+++ b/src/components/NotJunior/NotJunior.tsx
@@ -24,6 +24,7 @@ function NotJunior(props: NotJuniorProps) {
 
   const seniorJoin = () => {
     router.push(`/signup/select/common-info/matching-info`);
+    props.modalHandler();
   };
 
   return (

--- a/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
+++ b/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
@@ -10,6 +10,7 @@ import useModal from '@/hooks/useModal';
 import { createPortal } from 'react-dom';
 import Router, { useRouter } from 'next/navigation';
 import useAuth from '@/hooks/useAuth';
+import useDimmedModal from '@/hooks/useDimmedModal';
 import axios from 'axios';
 import {
   isTutorialFinished,
@@ -43,17 +44,13 @@ function SeniorManage(props: SeniorManageProps) {
     bModalHandler: props.modalHandler,
   });
 
-  const {
-    modal: setJModal,
-    modalHandler: juniorHandler,
-    portalElement: juniorPortal,
-  } = useModal('junior-request-portal');
+  const { openModal: openNotRegisteredModal } = useDimmedModal({
+    modalType: 'notRegistered',
+  });
 
-  const {
-    modal: registerModal,
-    modalHandler: registerHandler,
-    portalElement: registerPortal,
-  } = useModal('senior-profile-not-registered');
+  const { openModal: openNotJuniorModal } = useDimmedModal({
+    modalType: 'notJunior',
+  });
 
   const MyprofHandler = () => {
     if (checkRegister()) {
@@ -75,7 +72,7 @@ function SeniorManage(props: SeniorManageProps) {
   const checkRegister = () => {
     if (props.profileReg) return true;
     if (!props.profileReg) {
-      registerHandler();
+      openNotRegisteredModal();
       return false;
     }
   };
@@ -105,7 +102,7 @@ function SeniorManage(props: SeniorManageProps) {
 
           if (response.data.data.possible == false) {
             setSocialId(response.data.data.socialId);
-            juniorHandler();
+            openNotJuniorModal();
           }
         }
       });
@@ -198,22 +195,6 @@ function SeniorManage(props: SeniorManageProps) {
           onClick={changeJunior}
         />
       </SeniorManageContentContainer>
-
-      {registerModal && registerPortal
-        ? createPortal(
-            <DimmedModal
-              modalType="notRegistered"
-              modalHandler={registerHandler}
-            />,
-            registerPortal,
-          )
-        : null}
-      {setJModal && juniorPortal
-        ? createPortal(
-            <DimmedModal modalType="notJunior" modalHandler={juniorHandler} />,
-            juniorPortal,
-          )
-        : null}
     </SeniorManageContainer>
   );
 }

--- a/src/hooks/useDimmedModal.tsx
+++ b/src/hooks/useDimmedModal.tsx
@@ -1,0 +1,52 @@
+import DimmedModal from '@/components/Modal/DimmedModal';
+
+import { DimmedModalProps } from '@/types/modal/dimmed';
+import { overlay } from 'overlay-kit';
+import { useState } from 'react';
+
+interface UseDimmedModalProps extends DimmedModalProps {
+  overlayId?: string;
+}
+const useDimmedModal = ({ ...props }: Partial<UseDimmedModalProps>) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+    overlay.open(
+      ({ unmount }) => {
+        return (
+          <DimmedModal
+            {...props}
+            modalType={props?.modalType as DimmedModalProps['modalType']}
+            modalHandler={() => {
+              if (props.modalHandler) {
+                props.modalHandler();
+              }
+              closeModal(unmount);
+            }}
+          />
+        );
+      },
+      {
+        overlayId: props.overlayId ?? '',
+      },
+    );
+  };
+
+  const closeModal = (unmount: () => void) => {
+    setIsOpen(false);
+    unmount();
+  };
+
+  const toggleModal = () => {
+    if (isOpen) {
+      closeModal(() => {});
+    } else {
+      openModal();
+    }
+  };
+
+  return { openModal, closeModal, toggleModal, isOpen };
+};
+
+export default useDimmedModal;

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -84,7 +84,7 @@ const useKakaoLogin = () => {
             ),
           );
           if (!agreeActivateAccount) {
-            router.push('/signup/select');
+            router.push('/');
           }
         }
       } catch (error) {


### PR DESCRIPTION
## 🦝 PR 요약

기존의 useModal훅과 DimmedModal을 사용하는 것에서 불필요한 portal을 제거해주고 overlay-kit로 DimmedModal을 관리하도록 수정하였씁니다.

## ✨ PR 상세 내용

- FullModal 형태에 대응하는 useFullModal과 마찬가지의 훅인 useDimmedModal훅을 만들었습니다!
(https://github.com/WE-ARE-RACCOONS/postgraduate-front/pull/291)

- 불필요한 portal을 제거해주었습니다!

- 일부 모달의 경우 router.push를 하는 경우가 있는데 이 경우에도 modalHandler를 적용해, 모달을 닫도록 수정하였습니다.


## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
