### PR TITLE
RAC 439 Refactor: 선배 프로필 수정 RiseUpModal의 닫기 버튼 추가 및 스타일 수정

### DIFF
--- a/src/components/Button/SelectedBtn/SelectedBtn.styled.ts
+++ b/src/components/Button/SelectedBtn/SelectedBtn.styled.ts
@@ -1,24 +1,26 @@
 import styled from 'styled-components';
 
 export const StyledSelectedBtn = styled.button<{ $selected: boolean }>`
-  width: max-content;
-  height: 2.125rem;
+  min-width: 60px;
+  width: auto;
+  height: 2.25rem;
   margin: 0.25rem 0.5rem 0.25rem 0;
-  padding: 0.3rem 0.75rem;
+  padding: 0.3rem 0.5rem;
   font-size: 16px;
   font-family: Pretendard;
-  border-radius: 8px;
+  border-radius: 4px;
   cursor: pointer;
-  background-color: ${(props) => (props.$selected ? '#2FC4B2' : '#F8F9FA')};
-  color: ${(props) => (props.$selected ? '#fff' : '#ADB5BD')};
-  border: ${(props) => (props.$selected ? 'none' : '1px solid #DEE2E6')};
+  background-color: ${(props) =>
+    props.$selected ? '#2FC4B2' : 'rgba(124, 143, 141, 0.1)'};
+  color: ${(props) => (props.$selected ? '#fff' : '#4C4D4E')};
+  border: ${(props) => (props.$selected ? '1px solid #21B1A0' : '1px #D7D7D7')};
   font-weight: ${(props) => (props.$selected ? '700' : '400')};
 
   #selected-x-btn {
     width: 1rem;
     height: 1rem;
-    margin-left: 0.375rem;
-    margin-bottom: 0.2rem;
+    margin-left: 0.15rem;
+    margin-bottom: 0.15rem;
     cursor: pointer;
     vertical-align: middle;
   }

--- a/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
+++ b/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
@@ -5,7 +5,7 @@ export const ModalBackground = styled.div`
   top: 50%;
   background: rgba(0, 0, 0, 0.7);
   transform: translateY(-50%);
-  width: 360px;
+  width: 100%;
   height: 100vh;
 
   @keyframes modalAppear {

--- a/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
+++ b/src/components/Modal/RiseUpModal/RiseUpModal.styled.ts
@@ -5,7 +5,9 @@ export const ModalBackground = styled.div`
   top: 50%;
   background: rgba(0, 0, 0, 0.7);
   transform: translateY(-50%);
-  width: 100%;
+  width: 375px;
+  margin: 0 auto;
+  padding: 0;
   height: 100vh;
 
   @keyframes modalAppear {
@@ -20,13 +22,13 @@ export const ModalBackground = styled.div`
   }
 
   .rise-up-modal {
-    width: inherit;
+    width: 100%;
+    margin: 0 auto;
     height: 38rem;
     position: absolute;
     top: 7.9rem;
     animation: modalAppear 0.5s ease-out;
     border-radius: 1.9rem 1.9rem 0 0;
-    z-index: 1;
     background-color: #fff;
   }
 `;

--- a/src/components/SingleForm/KeywordForm/Keyword.styled.ts
+++ b/src/components/SingleForm/KeywordForm/Keyword.styled.ts
@@ -56,7 +56,20 @@ export const KeywordFormContainer = styled.div`
     border-radius: 12px;
     background-color: #2fc4b2;
     color: #fff;
-    font-size: 18px;
+    font-size: 16px;
+    font-weight: 700;
+    position: absolute;
+    bottom: 0;
+    cursor: pointer;
+  }
+  .keyword-close-btn {
+    width: 100%;
+    height: 3.313rem;
+    border: none;
+    border-radius: 12px;
+    background-color: #fff;
+    color: #6d747e;
+    font-size: 16px;
     font-weight: 700;
     position: absolute;
     bottom: 0;
@@ -69,10 +82,10 @@ export const KeywordFormContainer = styled.div`
     border-radius: 12px;
     background-color: #adb5bd;
     color: #fff;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 700;
     position: absolute;
-    bottom: 0;
+    bottom: 3.5rem;
     cursor: pointer;
   }
 `;

--- a/src/components/SingleForm/KeywordForm/Keyword.styled.ts
+++ b/src/components/SingleForm/KeywordForm/Keyword.styled.ts
@@ -10,6 +10,8 @@ export const KeywordFormContainer = styled.div`
 
   h3 {
     margin-bottom: 1rem;
+    font-size: 16px;
+    color: #020202;
   }
 
   #select-keyword-subtitle {
@@ -18,7 +20,7 @@ export const KeywordFormContainer = styled.div`
     font-size: 14px;
     display: flex;
     justify-content: space-between;
-    margin-bottom: 0.375rem;
+    margin-bottom: 7px;
 
     #select-keyword-subtitle-text {
       width: 3.7rem;
@@ -39,13 +41,12 @@ export const KeywordFormContainer = styled.div`
 
   #select-keyword-direction {
     width: 18.5rem;
-    height: 2.5rem;
-    color: #868e96;
-    font-size: 14px;
+    color: #464c51;
+    font-size: 13px;
     flex-wrap: pre;
     line-height: 140%;
     letter-spacing: -0.5px;
-    margin-bottom: 0.125rem;
+    margin-bottom: 7px;
   }
 
   #keyword-submit-btn {
@@ -61,7 +62,7 @@ export const KeywordFormContainer = styled.div`
     bottom: 0;
     cursor: pointer;
   }
-  #keyword-submit-btn-non {
+  .keyword-submit-btn-non {
     width: 100%;
     height: 3.313rem;
     border: none;
@@ -90,9 +91,8 @@ export const KeywordFormWrapper = styled.div`
 
 export const KeywordInputFormBox = styled.div`
   width: 100%;
-  height: 3.19rem;
   border-radius: 8px;
-  border: 1px solid #c2cede;
+  border: 1px solid #dcdfe4;
   background: #fff;
   margin-top: 0.625rem;
   padding: 1rem 0.5rem;

--- a/src/components/SingleForm/KeywordForm/Keyword.styled.ts
+++ b/src/components/SingleForm/KeywordForm/Keyword.styled.ts
@@ -104,6 +104,8 @@ export const KeywordFormWrapper = styled.div`
 
 export const KeywordInputFormBox = styled.div`
   width: 100%;
+  font-size: 13px;
+  height: 44px;
   border-radius: 8px;
   border: 1px solid #dcdfe4;
   background: #fff;

--- a/src/components/SingleForm/KeywordForm/KeywordForm.tsx
+++ b/src/components/SingleForm/KeywordForm/KeywordForm.tsx
@@ -87,6 +87,13 @@ function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
           저장
         </button>
       )}
+      <button
+        className="keyword-close-btn"
+        type="button"
+        onClick={clickHandler}
+      >
+        닫기
+      </button>
     </KeywordFormContainer>
   );
 }

--- a/src/components/SingleForm/KeywordForm/KeywordForm.tsx
+++ b/src/components/SingleForm/KeywordForm/KeywordForm.tsx
@@ -14,6 +14,7 @@ import {
 import { SELECT_KEYWORD_TEXT } from '@/constants/keyword/keyword';
 import SelectedBtn from '@/components/Button/SelectedBtn';
 import { useFormContext } from 'react-hook-form';
+import NextBtn from '@/components/Button/NextBtn';
 
 function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
   const {
@@ -45,18 +46,15 @@ function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
     <KeywordFormContainer>
       <KeywordFormWrapper>
         <h3 id="select-keyword-title">{SELECT_KEYWORD_TEXT.keywordTitle}</h3>
-        <div id="select-keyword-subtitle">
-          <div id="select-keyword-subtitle-text">
-            <div id="keyword-text">{SELECT_KEYWORD_TEXT.keywordText}</div>
-            <div id="keyword-star">*</div>
-          </div>
-          {errors?.keyword && (
-            <div id="keyword-alert">{SELECT_KEYWORD_TEXT.keywordAlert}</div>
-          )}
-        </div>
         <div id="select-keyword-direction">
           {SELECT_KEYWORD_TEXT.keywordDirection}
         </div>
+        <div id="select-keyword-subtitle">
+          {errors?.keyword && (
+            <div id="keyword-alert">*{SELECT_KEYWORD_TEXT.keywordAlert}</div>
+          )}
+        </div>
+
         <KeywordFormBtnContainer>
           {totalBtns &&
             totalBtns.map((el, idx) => (
@@ -70,7 +68,12 @@ function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
         </KeywordFormBtnContainer>
         {selected.length < 6 && (
           <KeywordInputFormBox>
-            <input id="keyword-input-form" {...register('keyword')} max={20} />
+            <input
+              id="keyword-input-form"
+              placeholder={SELECT_KEYWORD_TEXT.placeholder}
+              {...register('keyword')}
+              max={20}
+            />
             <button id="keyword-input-btn" onClick={addKeyword}>
               {SELECT_KEYWORD_TEXT.keywordInputBtnText}
             </button>
@@ -78,10 +81,10 @@ function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
         )}
       </KeywordFormWrapper>
       {selected.length === 0 ? (
-        <button id="keyword-submit-btn-non">확인</button>
+        <button className="keyword-submit-btn-non">저장</button>
       ) : (
         <button id="keyword-submit-btn" onClick={handleConfirm}>
-          확인
+          저장
         </button>
       )}
     </KeywordFormContainer>

--- a/src/components/SingleForm/SelectForm/SelectForm.styled.ts
+++ b/src/components/SingleForm/SelectForm/SelectForm.styled.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 export const SelectFormContainer = styled.div`
-  width: 20rem;
+  width: 90%;
+  margin: 0 auto;
   height: 70%;
   position: absolute;
   top: 2rem;
@@ -68,7 +69,6 @@ export const SelectFormContainer = styled.div`
 
 export const SelectFormBtnContainer = styled.div`
   width: 100%;
-  height: max-content;
 `;
 
 export const SelectFormWrapper = styled.div`

--- a/src/components/SingleForm/SelectForm/SelectForm.styled.ts
+++ b/src/components/SingleForm/SelectForm/SelectForm.styled.ts
@@ -5,44 +5,34 @@ export const SelectFormContainer = styled.div`
   height: 70%;
   position: absolute;
   top: 2rem;
+  color: #464c51;
   left: 50%;
   transform: translateX(-50%);
+  font-size: 13px;
 
   h3 {
     margin-bottom: 1rem;
+    font-size: 15px;
   }
 
   #select-field-subtitle {
-    width: 14.1rem;
-    height: 1.1rem;
     font-size: 14px;
     display: flex;
     justify-content: space-between;
     margin-bottom: 0.375rem;
 
-    #select-field-subtitle-text {
-      width: 3.7rem;
-      height: 1.1rem;
-      display: flex;
-      justify-content: space-between;
-
-      #field-star {
-        color: #00a0e1;
-        font-weight: 700;
-      }
-    }
-
     #field-alert {
       color: #ff5757;
+      font-size: 11.93px;
     }
   }
 
   #select-field-direction {
-    width: 12.5rem;
-    height: 2.5rem;
-    color: #868e96;
-    font-size: 14px;
-    flex-wrap: pre;
+    width: 100%;
+    display: inline-flex;
+    flex-wrap: wrap;
+    height: auto;
+    font-size: 13px;
     line-height: 140%;
     letter-spacing: -0.5px;
     margin-bottom: 0.125rem;
@@ -97,6 +87,7 @@ export const FieldInputFormBox = styled.div`
   margin-top: 0.625rem;
   padding: 1rem 0.5rem;
   display: flex;
+  align-items: center;
   font-size: 13px;
   justify-content: space-between;
 

--- a/src/components/SingleForm/SelectForm/SelectForm.styled.ts
+++ b/src/components/SingleForm/SelectForm/SelectForm.styled.ts
@@ -4,6 +4,7 @@ export const SelectFormContainer = styled.div`
   width: 90%;
   margin: 0 auto;
   height: 70%;
+  overflow: hidden;
   position: absolute;
   top: 2rem;
   color: #464c51;
@@ -38,6 +39,19 @@ export const SelectFormContainer = styled.div`
     letter-spacing: -0.5px;
     margin-bottom: 0.125rem;
   }
+  .field-close-btn {
+    width: 100%;
+    height: 3.313rem;
+    border: none;
+    border-radius: 12px;
+    background-color: #fff;
+    color: #6d747e;
+    font-size: 18px;
+    font-weight: 700;
+    position: absolute;
+    bottom: 0;
+    cursor: pointer;
+  }
 
   #field-submit-btn {
     width: 100%;
@@ -49,7 +63,7 @@ export const SelectFormContainer = styled.div`
     font-size: 18px;
     font-weight: 700;
     position: absolute;
-    bottom: 0;
+    bottom: 3.5rem;
     cursor: pointer;
   }
   #field-submit-btn-non {
@@ -62,7 +76,7 @@ export const SelectFormContainer = styled.div`
     font-size: 18px;
     font-weight: 700;
     position: absolute;
-    bottom: 0;
+    bottom: 3.5rem;
     cursor: pointer;
   }
 `;

--- a/src/components/SingleForm/SelectForm/SelectForm.tsx
+++ b/src/components/SingleForm/SelectForm/SelectForm.tsx
@@ -16,7 +16,6 @@ function SelectForm(props: SelectFormProps) {
   const {
     register,
     watch,
-    setError,
     setValue,
     formState: { errors },
   } = useFormContext();
@@ -44,18 +43,16 @@ function SelectForm(props: SelectFormProps) {
     <SelectFormContainer>
       <SelectFormWrapper>
         <h3 id="select-field-title">{SELECT_FIELD_TEXT.fieldTitle}</h3>
-        <div id="select-field-subtitle">
-          <div id="select-field-subtitle-text">
-            <div id="field-text">{SELECT_FIELD_TEXT.fieldText}</div>
-            <div id="field-star">*</div>
-          </div>
-          {errors?.field?.message && (
-            <div id="field-alert">{SELECT_FIELD_TEXT.fieldAlert}</div>
-          )}
-        </div>
+
         <div id="select-field-direction">
-          {SELECT_FIELD_TEXT.fieldDirection}
+          <div>{SELECT_FIELD_TEXT.fieldDirection}</div>
+          <div id="select-field-subtitle">
+            {errors?.field?.message && (
+              <div id="field-alert">*{SELECT_FIELD_TEXT.fieldAlert}</div>
+            )}
+          </div>
         </div>
+
         <SelectFormBtnContainer>
           {totalBtns &&
             totalBtns.map((el, idx) => (
@@ -71,17 +68,21 @@ function SelectForm(props: SelectFormProps) {
             ))}
         </SelectFormBtnContainer>
         <FieldInputFormBox>
-          <input id="field-input-form" {...register('field')} />
+          <input
+            id="field-input-form"
+            placeholder={SELECT_FIELD_TEXT.placeholder}
+            {...register('field')}
+          />
           <button id="field-input-btn" onClick={handleAddOtherField}>
             {SELECT_FIELD_TEXT.fieldInputBtnText}
           </button>
         </FieldInputFormBox>
       </SelectFormWrapper>
       {selected.length === 0 ? (
-        <button id="field-submit-btn-non">확인</button>
+        <button id="field-submit-btn-non">저장</button>
       ) : (
         <button id="field-submit-btn" onClick={handleConfirm}>
-          확인
+          저장
         </button>
       )}
     </SelectFormContainer>

--- a/src/components/SingleForm/SelectForm/SelectForm.tsx
+++ b/src/components/SingleForm/SelectForm/SelectForm.tsx
@@ -85,6 +85,9 @@ function SelectForm(props: SelectFormProps) {
           저장
         </button>
       )}
+      <button className="field-close-btn" onClick={props.clickHandler}>
+        닫기
+      </button>
     </SelectFormContainer>
   );
 }

--- a/src/constants/field/field.ts
+++ b/src/constants/field/field.ts
@@ -2,7 +2,8 @@ export const SELECT_FIELD_TEXT = {
   fieldTitle: '연구 분야에 대해 알려주세요.',
   fieldText: '연구분야',
   fieldAlert: '최소 1개 이상을 선택해주세요',
-  fieldDirection: `연구실이 연구중인 분야를 선택하거나\n직접 입력해주세요.`,
+  fieldDirection: `연구 분야는 가장 적합하다고 생각하시는 분야를 선택하거나 \n 입력해 주시면 됩니다.`,
   fieldInputDirection: '연구분야를 직접 입력해주세요.',
-  fieldInputBtnText: '입력완료',
+  fieldInputBtnText: '추가',
+  placeholder: '연구 분야를 직접 입력해주세요. ',
 };

--- a/src/constants/keyword/keyword.ts
+++ b/src/constants/keyword/keyword.ts
@@ -2,7 +2,8 @@ export const SELECT_KEYWORD_TEXT = {
   keywordTitle: '연구 주제에 대해 알려주세요.',
   keywordText: '연구주제',
   keywordAlert: '최소 1개 이상을 선택해주세요',
-  keywordDirection: `연구실의  연구 주제를 잘 설명하는 키워드를 알려주세요.\n키워드 입력 후 ‘입력완료' 버튼을 누르면 추가됩니다.`,
+  keywordDirection: `연구 주제를 잘 설명하는 키워드를 알려 주세요`,
   keywordInputDirection: '연구주제를 직접 입력해주세요.',
-  keywordInputBtnText: '입력완료',
+  keywordInputBtnText: '추가',
+  placeholder: '연구 분야를 직접 입력해 주세요.',
 };

--- a/src/constants/keyword/keyword.ts
+++ b/src/constants/keyword/keyword.ts
@@ -5,5 +5,5 @@ export const SELECT_KEYWORD_TEXT = {
   keywordDirection: `연구 주제를 잘 설명하는 키워드를 알려 주세요`,
   keywordInputDirection: '연구주제를 직접 입력해주세요.',
   keywordInputBtnText: '추가',
-  placeholder: '연구 분야를 직접 입력해 주세요.',
+  placeholder: '연구 주제를 직접 입력해 주세요.',
 };


### PR DESCRIPTION
## 🦝 PR 요약

선배 프로필 수정 UI의 연구 주재, 연구 분야 모달에 대해 스타일을 수정하였씁니다.

## ✨ PR 상세 내용

아래 스크린샷대로 `RiseUpModal`중 `SelectForm`, `KeywordForm`의 스타일을 일부 수정하고,
각 모달마다 닫기 버튼 UI를 추가해두었습니다!

![image](https://github.com/user-attachments/assets/943128d2-0bae-4a46-a858-2ae88ff84341)

![image](https://github.com/user-attachments/assets/78915966-521a-48e5-a4ad-1ca768d0ec6a)


## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
