### PR TITLE
RAC 437 Refactor: 탈퇴 문구 수정 및 선배 리스트 조회 Query를 사용하도록 수정

### DIFF
--- a/src/api/senior/getSeinorList.ts
+++ b/src/api/senior/getSeinorList.ts
@@ -1,0 +1,47 @@
+import { withOutAuthInstance } from '@/api/api';
+import { ResponseModel } from '@/api/model';
+
+interface GetSeniorListRequest {
+  field: string;
+  postgradu: string;
+  page: number;
+}
+
+interface SeniorItem {
+  seniorId: number;
+  certification: boolean;
+  profile: string;
+  nickName: string;
+  postgradu: string;
+  major: string;
+  lab: string;
+  professor: string;
+  keyword: string[];
+}
+
+interface GetSeniorListResponse extends ResponseModel {
+  data: {
+    seniorSearchResponses: SeniorItem[];
+    totalElements: number;
+  };
+}
+export const getSeniorList = async ({
+  field,
+  page,
+  postgradu,
+}: GetSeniorListRequest) => {
+  try {
+    return await withOutAuthInstance.get<GetSeniorListResponse>(
+      '/senior/field',
+      {
+        params: {
+          field,
+          page,
+          postgradu,
+        },
+      },
+    );
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/app/add-profile/schema.ts
+++ b/src/app/add-profile/schema.ts
@@ -28,7 +28,6 @@ export const validateAddProfileError = async (data: AddProfile) => {
     await addProfileSchema.validate(data);
   } catch (e) {
     if (e instanceof ValidationError) {
-      console.log(e);
       throw e;
     }
   }

--- a/src/app/signout/(components)/signout-info/index.tsx
+++ b/src/app/signout/(components)/signout-info/index.tsx
@@ -16,11 +16,11 @@ export function SignOutInfo({ onClick }: { onClick: () => void }) {
         </div>
 
         <div>
-          3. 탈퇴 후에는 같은 휴대전화 번호로 일정 기간 동안 재가입이
-          제한됩니다. 회원 탈퇴를 신중히 진행해주세요.
+          3. 탈퇴 후에는 같은 계정으로 30일 동안 재가입이 제한됩니다. 회원
+          탈퇴를 신중히 진행해주세요.
         </div>
 
-        <div>4. 탈퇴 후 15일 이내 재가입이 가능합니다.</div>
+        <div>4. 탈퇴 후 15일 이내 로그인 시 재활성화가 가능합니다.</div>
       </SignOutInfoContent>
       <div className="nextBtn_container">
         <NextBtn kind={'route'} btnText="다음으로" onClick={onClick} />

--- a/src/components/Provider/providers.tsx
+++ b/src/components/Provider/providers.tsx
@@ -5,6 +5,7 @@ import ArrowLeft from '../../../public/left_white.png';
 import { TourProvider } from '@reactour/tour';
 import { Provider as JotaiProvider } from 'jotai';
 import styled from 'styled-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 interface StepTextProps {
   size?: string;
@@ -77,82 +78,86 @@ const tourSteps = [
   },
 ];
 
+const queryClient = new QueryClient();
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <JotaiProvider>
-      <TourProvider
-        position={'top'}
-        showNavigation
-        scrollSmooth
-        styles={{
-          close: (base) => ({
-            ...base,
-            color: '#ffffff',
-          }),
-          popover: (base) => ({
-            ...base,
-            color: '#2fc4b2',
-            background: 'none',
-            boxShadow: 'none',
-            '--reactour-accent': '#2FC4B2',
-          }),
-          maskWrapper: (base) => ({
-            ...base,
-            background: 'none',
-          }),
-          controls: (base) => ({
-            ...base,
-            background: 'none',
-          }),
-          badge: (base) => ({
-            ...base,
-            opacity: 0,
-          }),
-          dot: (base) => ({
-            ...base,
-          }),
-          button: (base) => ({
-            ...base,
-            color: '#ffffff',
-            svg: '#ffffff',
-            stroke: '#ffffff',
-          }),
-          maskRect: (base) => ({
-            ...base,
-            background: 'none',
-          }),
-        }}
-        disableKeyboardNavigation
-        steps={tourSteps}
-        nextButton={(props) => (
-          <Image
-            src={ArrowRight}
-            alt="튜토리얼_다음버튼"
-            width={30}
-            height={30}
-            onClick={() => props.setCurrentStep(props.currentStep + 1)}
-            style={{
-              cursor: 'pointer',
-            }}
-            {...props}
-          />
-        )}
-        prevButton={(props) => (
-          <Image
-            src={ArrowLeft}
-            alt="튜토리얼_이전버튼"
-            width={30}
-            height={30}
-            onClick={() => props.setCurrentStep(props.currentStep - 1)}
-            style={{
-              cursor: 'pointer',
-            }}
-            {...props}
-          />
-        )}
-      >
-        {children}
-      </TourProvider>
-    </JotaiProvider>
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider>
+        <TourProvider
+          position={'top'}
+          showNavigation
+          scrollSmooth
+          styles={{
+            close: (base) => ({
+              ...base,
+              color: '#ffffff',
+            }),
+            popover: (base) => ({
+              ...base,
+              color: '#2fc4b2',
+              background: 'none',
+              boxShadow: 'none',
+              '--reactour-accent': '#2FC4B2',
+            }),
+            maskWrapper: (base) => ({
+              ...base,
+              background: 'none',
+            }),
+            controls: (base) => ({
+              ...base,
+              background: 'none',
+            }),
+            badge: (base) => ({
+              ...base,
+              opacity: 0,
+            }),
+            dot: (base) => ({
+              ...base,
+            }),
+            button: (base) => ({
+              ...base,
+              color: '#ffffff',
+              svg: '#ffffff',
+              stroke: '#ffffff',
+            }),
+            maskRect: (base) => ({
+              ...base,
+              background: 'none',
+            }),
+          }}
+          disableKeyboardNavigation
+          steps={tourSteps}
+          nextButton={(props) => (
+            <Image
+              src={ArrowRight}
+              alt="튜토리얼_다음버튼"
+              width={30}
+              height={30}
+              onClick={() => props.setCurrentStep(props.currentStep + 1)}
+              style={{
+                cursor: 'pointer',
+              }}
+              {...props}
+            />
+          )}
+          prevButton={(props) => (
+            <Image
+              src={ArrowLeft}
+              alt="튜토리얼_이전버튼"
+              width={30}
+              height={30}
+              onClick={() => props.setCurrentStep(props.currentStep - 1)}
+              style={{
+                cursor: 'pointer',
+              }}
+              {...props}
+            />
+          )}
+        >
+          {children}
+        </TourProvider>
+      </JotaiProvider>
+    </QueryClientProvider>
   );
 }

--- a/src/components/SeniorProfile/SeniorProfile.tsx
+++ b/src/components/SeniorProfile/SeniorProfile.tsx
@@ -18,7 +18,6 @@ import auth from '../../../public/auth_mark.png';
 function SeniorProfile({ data }: SeniorProfileProps) {
   const router = useRouter();
 
-  console.log(data);
   return (
     <SeniorProfileBox className="tutorial_card">
       <SPWrapper>

--- a/src/hooks/query/useGetSeniorListQuery.ts
+++ b/src/hooks/query/useGetSeniorListQuery.ts
@@ -1,0 +1,16 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getSeniorList } from '@/api/senior/getSeinorList';
+
+export const useGetSeniorListQuery = (field: string, postgradu: string) => {
+  return useInfiniteQuery({
+    suspense: true,
+    queryKey: ['seniorList', field, postgradu],
+    queryFn: ({ pageParam = 1 }) =>
+      getSeniorList({ field, postgradu, page: pageParam }),
+    getNextPageParam: (lastPage, allPages) => {
+      const totalPages = lastPage.data.data.totalElements;
+      const nextPage = allPages.length + 1;
+      return nextPage <= totalPages ? nextPage : undefined;
+    },
+  });
+};


### PR DESCRIPTION
## 🦝 PR 요약

- 저번 주 회의 때 나왔던 탈퇴 시 안내 페이지의 문구를 수정했어요.
- 선배 리스트 조회 부분을 `useInfinityQuery`로 변경하였습니다.

## ✨ PR 상세 내용

쿼리와 API를 실제 호출하는 부분의 분리를 같이 가져갈지 아니면, 따로 분리해야 할지 고민입니다.
음 예를 들어 선배 리스트 조회인 `getSeniorList`를 `useGetSeniorListQuery`와 분리한다면 이 쿼리에서는 요 API만 쓰인다가 명확해지만, `api`레이어가 있는 상황에서 이를 분리해도 될 지 고민이 되네요..

`쿼리를 도입할 때의 에러처리`를 개발 회의 때 이야기 하면 좋을 것 같습니다.
점진적으로 쿼리를 통해 리팩토링을 하다보니, 쿼리나 `mutation`시 예외처리에 대해 찾아보고 정하면 좋을 것 같아요!
(요건 오늘 저녁 회의때 이야기 해봐용!!)

무한스크롤 시 `scroll`을 쓰는 것과 `intersection obvserver`를 쓰는 것에 대해 장단점을 ,, 찾아보겠습니다!
요것도 저녁 때 이야기 해볼게용

## 🚨 주의 사항

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/3e2f7cb4-1921-4b21-be6d-8ec8da5352b2)


## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
