### PR TITLE
RAC 445: Refactor : 선배 프로필 보기로 이동 시 멘토링 신청 버튼이 나타나는 문제 해결

### DIFF
--- a/src/api/senior/[id]/getDetailSeniorInfo.ts
+++ b/src/api/senior/[id]/getDetailSeniorInfo.ts
@@ -1,5 +1,5 @@
 import { ResponseModel } from '@/api/model';
-import { withOutAuthInstance } from '@/api/api';
+import { withAuthInstance, withOutAuthInstance } from '@/api/api';
 
 interface SeniorInfoRequest {
   seniorId: string;
@@ -32,6 +32,11 @@ export interface TimeObj {
 export const getDetailSeniorInfoFetch = async ({
   seniorId,
 }: SeniorInfoRequest) => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return (
+      await withAuthInstance.get<SeniorInfoResponse>(`/senior/${seniorId}`)
+    ).data.data;
+  }
   return (
     await withOutAuthInstance.get<SeniorInfoResponse>(`/senior/${seniorId}`)
   ).data.data;

--- a/src/api/user/_images/postUserProfileImage.ts
+++ b/src/api/user/_images/postUserProfileImage.ts
@@ -20,5 +20,10 @@ export const postUserProfileImage = async ({
   return await withAuthInstance.post<PostUserProfileImageResponse>(
     '/image/upload/profile',
     formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
   );
 };

--- a/src/app/add-chat-link/page.tsx
+++ b/src/app/add-chat-link/page.tsx
@@ -17,11 +17,8 @@ import {
   sKeywordAtom,
   sLabAtom,
   sMajorAtom,
-  sMultiIntroduce,
   sPostGraduAtom,
   sProfessorAtom,
-  sRecommendedFor,
-  sSingleIntroduce,
 } from '@/stores/senior';
 import { changeNickname, phoneNum } from '@/stores/signup';
 import findExCode from '@/utils/findExCode';

--- a/src/app/senior/info/[seniorId]/SeniorInfo.tsx
+++ b/src/app/senior/info/[seniorId]/SeniorInfo.tsx
@@ -21,9 +21,13 @@ export function SeniorInfoPage({ params }: { params: { seniorId: string } }) {
 
   const koreanCharWidth = 1.2;
 
-  const { data, isLoading } = useGetSeniorInfoQuery({
+  const { data, isLoading, refetch } = useGetSeniorInfoQuery({
     seniorId: params.seniorId,
   });
+
+  useEffect(() => {
+    refetch();
+  }, []);
 
   const { getUserType } = useAuth();
 

--- a/src/app/senior/info/[seniorId]/SeniorInfo.tsx
+++ b/src/app/senior/info/[seniorId]/SeniorInfo.tsx
@@ -5,11 +5,12 @@ const IntroCard = dynamic(() => import('@/components/Card/IntroCard'));
 const KeywordCard = dynamic(() => import('@/components/Card/KeywordCard'));
 const ProfileCard = dynamic(() => import('@/components/Card/ProfileCard'));
 const BackHeader = dynamic(() => import('@/components/Header/BackHeader'));
+import styled from 'styled-components';
 import useAuth from '@/hooks/useAuth';
 
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
+
 import { ErrorBoundary } from 'react-error-boundary';
 
 import useDimmedModal from '@/hooks/useDimmedModal';
@@ -20,7 +21,9 @@ export function SeniorInfoPage({ params }: { params: { seniorId: string } }) {
 
   const koreanCharWidth = 1.2;
 
-  const { data } = useGetSeniorInfoQuery({ seniorId: params.seniorId });
+  const { data, isLoading } = useGetSeniorInfoQuery({
+    seniorId: params.seniorId,
+  });
 
   const { getUserType } = useAuth();
 
@@ -111,11 +114,9 @@ export function SeniorInfoPage({ params }: { params: { seniorId: string } }) {
         {isMine ? (
           <MentoringApplyBtn onClick={editHandler}>수정하기</MentoringApplyBtn>
         ) : (
-          <>
-            <MentoringApplyBtn onClick={applyHandler}>
-              멘토링 신청
-            </MentoringApplyBtn>
-          </>
+          <MentoringApplyBtn onClick={applyHandler}>
+            멘토링 신청
+          </MentoringApplyBtn>
         )}
       </SeniorInfoPageContainer>
     </ErrorBoundary>

--- a/src/app/senior/info/[seniorId]/SeniorInfo.tsx
+++ b/src/app/senior/info/[seniorId]/SeniorInfo.tsx
@@ -17,7 +17,7 @@ import { useGetSeniorInfoQuery } from '@/hooks/query/useGetSeniorInfo';
 
 export function SeniorInfoPage({ params }: { params: { seniorId: string } }) {
   const router = useRouter();
-  const currentPath = usePathname();
+
   const koreanCharWidth = 1.2;
 
   const { data } = useGetSeniorInfoQuery({ seniorId: params.seniorId });

--- a/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
+++ b/src/components/Profile/ProfileManage/SeniorManage/SeniorManage.tsx
@@ -6,8 +6,6 @@ import ContentComponent from '../../Box/ContentBox';
 import TitleComponent from '../../Box/TitleBox';
 import { SeniorManageProps } from '@/types/profile/seniorManage';
 
-import useModal from '@/hooks/useModal';
-import { createPortal } from 'react-dom';
 import Router, { useRouter } from 'next/navigation';
 import useAuth from '@/hooks/useAuth';
 import useDimmedModal from '@/hooks/useDimmedModal';

--- a/src/hooks/mutations/usePostProfileImage.ts
+++ b/src/hooks/mutations/usePostProfileImage.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { postUserProfileImage } from '@/api/user/_images/postUserProfileImage';
+
+export const usePostProfileImage = () => {
+  return useMutation({
+    mutationFn: postUserProfileImage,
+  });
+};


### PR DESCRIPTION
## 🦝 PR 요약

기존 버그 중 선배 프로필 보기로 이동 시 내 계정의 경우 멘토링 신청 버튼이 나타납니다.
해당 멘토링 신청 버튼은 나의 계정에서는 나타나지 않아야 합니다.

## ✨ PR 상세 내용

해당 문제는 ssr을 도입하면서 나타났는데요. 먼저 `선배 프로필 조회` 시 `내 계정`의 경우 accessToken으로 판별하고 있습니다.
그러나 ssr을 사용할 때에는 accessToken에 접근하는 순간(클라이언트 사이드의 로컬스토리지) 바로 오류가 나는데요.

그래서 ssr을 클라이언트 로직이 들어가지 않은 단순 정보 조회인 선배 리스트 정보나 선배 상세 정보 조회에만 적용한 상태였습니다.
그러나 `선배 상세 조회`시 해당 계장이 나의 계정인지를 판별하는 부분이 필요했고, 결국 ssr을 도입하고,

클라이언트 사이드로 진입 시 (hydration)후, 다시 refetch하는 것으로 수정하였어요.!

qa사항 중 개인정보 수정에 대해서는 주말에 마무리 해놓을게요

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
