### PR TITLE
RAC 447 Refactor: 사이트맵 404페이지 제거 및 선배 정보 페이지만 등록

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,9 +7,6 @@ export default async function sitemap() {
     );
     const data = await response.json();
 
-    if (data.code === 'SNR200') {
-      seniorIds = data.data.seniorIds;
-    }
     const sitemap: SitemapFile[] = [
       {
         url: 'https://kimseonbae.com',


### PR DESCRIPTION
## 🦝 PR 요약

사이트맵에 필요한 주소들만 넣어주었습니다.

## ✨ PR 상세 내용

404 사이트맵 페이지 제거, 정상적인 url만 등록하도록 재설정
기존 사이트맵 설정의 주소들이 404되어있는 주소가 많더라고요!

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
