### PR TITLE
RAC-448 Fix: 15-30일 사이 탈퇴 유저 오류 처리, 로그인 하지 않은 사용자의 선배 상세 조회 오류 해결

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -15,8 +15,9 @@ withAuthInstance.interceptors.request.use(
   ): Promise<InternalAxiosRequestConfig> => {
     const { getAccessToken } = useAuth();
     const accessTkn = await getAccessToken();
-
-    config.headers.Authorization = `Bearer ${accessTkn}`;
+    if (accessTkn) {
+      config.headers.Authorization = `Bearer ${accessTkn}`;
+    }
 
     return config;
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.ico',
   },
-  metadataBase: new URL('https://develop.dttx948lk1tf.amplifyapp.com'),
+  metadataBase: new URL('https://www.kimseonbae.com'),
   alternates: {
     canonical: '/',
     languages: {

--- a/src/components/SingleForm/KeywordForm/Keyword.styled.ts
+++ b/src/components/SingleForm/KeywordForm/Keyword.styled.ts
@@ -58,21 +58,17 @@ export const KeywordFormContainer = styled.div`
     color: #fff;
     font-size: 16px;
     font-weight: 700;
-    position: absolute;
-    bottom: 0;
     cursor: pointer;
   }
   .keyword-close-btn {
     width: 100%;
-    height: 3.313rem;
+    height: 50px;
     border: none;
     border-radius: 12px;
     background-color: #fff;
     color: #6d747e;
     font-size: 16px;
     font-weight: 700;
-    position: absolute;
-    bottom: 0;
     cursor: pointer;
   }
   .keyword-submit-btn-non {
@@ -105,7 +101,6 @@ export const KeywordFormWrapper = styled.div`
 export const KeywordInputFormBox = styled.div`
   width: 100%;
   font-size: 13px;
-  height: 44px;
   border-radius: 8px;
   border: 1px solid #dcdfe4;
   background: #fff;

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import useAuth from '@/hooks/useAuth';
-import AccountReactivation from '@/components/Content/AccountReactivation';
 import { useSetAtom } from 'jotai';
 import { socialIdAtom, isTutorialFinished } from '@/stores/signup';
 import { overlay } from 'overlay-kit';
@@ -11,6 +10,7 @@ import {
 } from '@/api/auth/login/kakaoAuthFetch';
 import { rejoinPatchFetch } from '@/api/auth/rejoin/rejoinPatchFetch';
 import FullModal from '@/components/Modal/FullModal';
+import findExCode from '@/utils/findExCode';
 
 const useKakaoLogin = () => {
   const setSocialId = useSetAtom(socialIdAtom);
@@ -50,6 +50,12 @@ const useKakaoLogin = () => {
 
         if (kakaoAuthFetchRes.code === 'AU204') {
           setUserContext(kakaoAuthFetchRes);
+          router.push('/');
+          return;
+        }
+
+        if (findExCode(kakaoAuthFetchRes.code)) {
+          alert('탈퇴 후 15일에서 30일 사이에는 로그인이 불가능합니다.');
           router.push('/');
           return;
         }


### PR DESCRIPTION
## 🦝 PR 요약

- 탈퇴 후 15~30일 사이 유저 케이스 처리
- 로그인 한 사용자가 선배 상세 조회 시 500에러 처리

## ✨ PR 상세 내용

1. 로그인 한 사용자가 선배 상세 조회 시 500에러 처리
    - 원인 파악중…
2.  [[탈퇴 후 15~30일 사이 로그인 실패 처리 문제](https://www.notion.so/15-30-3ee04e5e1eb64f269b71333a1942bdde?pvs=21)](https://www.notion.so/15-30-3ee04e5e1eb64f269b71333a1942bdde?pvs=21) 
    - `isDelete = true` 탈퇴한지 1일 ~ 15일 사이
    - `EX301` 은, 과거에 회원가입 이력이 있으나, 탈퇴한지 15일에서 30일 사이인 회원
        - 이 경우에는 아예 진행이 안됨.

## 🚨 주의 사항

## 📸 스크린샷


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
