### PR TITLE
RAC 453: 최종 릴리즈 전 QA 목록들 반영

### DIFF
--- a/src/api/mentoring/confirmSeniorMentoring.ts
+++ b/src/api/mentoring/confirmSeniorMentoring.ts
@@ -1,0 +1,29 @@
+import { withAuthInstance } from '../api';
+import { ResponseModel } from '../model';
+
+interface SeniorConfirmMentoringResponse extends ResponseModel {
+  data: boolean;
+}
+
+//mentoring/senior/me/${props.mentoringId}/expected
+
+export const confirmSeniorMentoring = async ({
+  date,
+  mentoringId,
+}: {
+  date: string;
+  mentoringId: number;
+}) => {
+  try {
+    return (
+      await withAuthInstance.patch<SeniorConfirmMentoringResponse>(
+        `/mentoring/senior/me/${mentoringId}/expected`,
+        {
+          date,
+        },
+      )
+    ).data;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/api/mentoring/cancelMentoring.ts
+++ b/src/api/mentoring/cancelMentoring.ts
@@ -1,0 +1,16 @@
+import { withAuthInstance } from '../api';
+import { ResponseModel } from '../model';
+
+interface CancelMentoringResponse extends ResponseModel {
+  data: string;
+}
+
+export const cancleMentoring = async (mentoringId: number) => {
+  try {
+    return await withAuthInstance.patch<CancelMentoringResponse>(
+      `/mentoring/me/${mentoringId}/cancel`,
+    );
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/api/mentoring/confirmMentoring.ts
+++ b/src/api/mentoring/confirmMentoring.ts
@@ -1,0 +1,26 @@
+//mentoring/me/${mentoringId}/done
+import { ResponseModel } from '../model';
+import { withAuthInstance } from '../api';
+import findExCode from '@/utils/findExCode';
+
+interface ConfirmMentoringResponse extends ResponseModel {
+  data: string;
+}
+
+export const confirmMentoring = async ({
+  mentoringId,
+}: {
+  mentoringId: number;
+}) => {
+  try {
+    const response = await withAuthInstance.patch<ConfirmMentoringResponse>(
+      `/mentoring/me/${mentoringId}/done`,
+    );
+    if (findExCode(response.data.code)) {
+      throw new Error(response.data.message);
+    }
+    return response.data;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/api/mentoring/getMyApplyMentoringList.ts
+++ b/src/api/mentoring/getMyApplyMentoringList.ts
@@ -1,0 +1,28 @@
+import { ResponseModel } from '../model';
+import { withAuthInstance } from '../api';
+
+interface GetMyApplyMentoringList extends ResponseModel {
+  data: {
+    seniorId: string;
+    profile: string;
+    nickName: string;
+    postgradu: string;
+    major: string;
+    lab: string;
+    topic: string;
+    question: string;
+    dates: string[];
+  };
+}
+
+export const getMyApplyMentoringList = async (mentoringId: number) => {
+  try {
+    return (
+      await withAuthInstance.get<GetMyApplyMentoringList>(
+        `/mentoring/me/${mentoringId}`,
+      )
+    ).data.data;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/api/mentoring/getSeniorMentoringList.ts
+++ b/src/api/mentoring/getSeniorMentoringList.ts
@@ -1,0 +1,31 @@
+//mentoring/senior/me/${props.mentoringId}
+
+import { ResponseModel } from '../model';
+
+interface GetSeniorMentoringListResponse extends ResponseModel {
+  data: {
+    profile: string;
+    nickName: string;
+    topic: string;
+    question: string;
+    dates: string[];
+    term: number;
+  };
+}
+import { withAuthInstance } from '../api';
+
+export const getSeniorMentoringList = async ({
+  mentoringId,
+}: {
+  mentoringId: number;
+}) => {
+  try {
+    return (
+      await withAuthInstance.get<GetSeniorMentoringListResponse>(
+        `/mentoring/senior/me/${mentoringId}`,
+      )
+    ).data.data;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -34,7 +34,7 @@ function page() {
   const router = useRouter();
 
   const availability = useAtomValue(notDuplicate);
-  const availablePhone = useAtomValue(phoneNumValidation);
+  const [availablePhone, setAvailablePhone] = useAtom(phoneNumValidation);
   const newAvailability = useAtomValue(newNotDuplicate);
   const sameUser = useAtomValue(sameUserAtom);
   const fullNum = useAtomValue(phoneNum);
@@ -44,9 +44,11 @@ function page() {
         removeTokens();
         location.reload();
       }
-      const { nickName, profile } = res.data.data;
+      const { nickName, profile, phoneNumber } = res.data.data;
       setNickName(nickName);
       setprofile(profile);
+      setPhoneNumber(phoneNumber);
+      setAvailablePhone(false);
     });
   }, []);
 

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -29,6 +29,7 @@ import { JMCancelAtom } from '@/stores/condition';
 import { REVIEW_FORM_URL } from '@/constants/form/reviewForm';
 import { StyledSModalBtn } from '@/components/Button/ModalBtn/ModalBtn.styled';
 import MentoringNotYet from '@/components/MentoringNotYet';
+import { useConfirmMyMentoring } from '@/hooks/mutations/useConfirmMyMentoring';
 
 function convertDateType(date: string) {
   if (!date) return new Date();
@@ -69,6 +70,7 @@ function TabBar() {
   const [prevMentoringInfoLength, setPrevMentoringInfoLength] = useState(0);
   const JMCancel = useAtomValue(JMCancelAtom);
 
+  const { mutate: confirmMyMentoring } = useConfirmMyMentoring();
   useEffect(() => {
     let prevMentoringInfoLength = 0;
     if (JMCancel === true) {
@@ -112,32 +114,16 @@ function TabBar() {
 
   const mentoConfirmed = async () => {
     const mentoringId = localStorage.getItem('mentoringId');
-    getAccessToken().then(async (Token) => {
-      if (Token) {
-        const headers = {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${Token}`,
-        };
-
-        const response = await axios.patch(
-          `${process.env.NEXT_PUBLIC_SERVER_URL}/mentoring/me/${mentoringId}/done`,
-          {
-            mentoringId: mentoringId,
+    if (mentoringId) {
+      confirmMyMentoring(
+        { mentoringId: Number(mentoringId) },
+        {
+          onSuccess: () => {
+            localStorage.removeItem('mentoringId');
           },
-          { headers },
-        );
-
-        if (findExCode(response.data.code)) {
-          removeTokens();
-          location.reload();
-          return;
-        }
-
-        const confirm = response.data;
-        localStorage.removeItem('mentoringId');
-        location.reload();
-      }
-    });
+        },
+      );
+    }
   };
 
   return (

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -42,9 +42,6 @@ function convertDateType(date: string) {
   return new Date(year, month, day, hour, minute);
 }
 function TabBar() {
-  const { openModal: openJuniorMentoringSpecModal } = useFullModal({
-    modalType: 'junior-mentoring-spec',
-  });
   const router = useRouter();
   const [modalType, setModalType] = useState<ModalMentoringType>('junior');
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
@@ -62,6 +59,13 @@ function TabBar() {
   const [selectedMentoringId, setSelectedMentoringId] = useState<number | null>(
     null,
   );
+  const {
+    openModal: openJuniorMentoringSpecModal,
+    closeModal: closeJunuiorMentoringSpec,
+  } = useFullModal({
+    modalType: 'junior-mentoring-spec',
+    selectedMentoringId: selectedMentoringId ?? 0,
+  });
   const [prevMentoringInfoLength, setPrevMentoringInfoLength] = useState(0);
   const JMCancel = useAtomValue(JMCancelAtom);
   useEffect(() => {
@@ -147,10 +151,11 @@ function TabBar() {
                   <ModalBtn
                     type={'show'}
                     btnText={'내 신청서 보기'}
-                    modalHandler={openJuniorMentoringSpecModal}
+                    modalHandler={() => {}}
                     onClick={() => {
                       setModalType('junior');
-                      setSelectedMentoringId(el.mentoringId);
+                      setSelectedMentoringId(() => el.mentoringId);
+                      openJuniorMentoringSpecModal();
                     }}
                   />
                 )}
@@ -172,10 +177,16 @@ function TabBar() {
                       <ModalBtn
                         type={'show'}
                         btnText={'내 신청서 보기'}
-                        modalHandler={openJuniorMentoringSpecModal}
+                        modalHandler={() => {
+                          if (selectedMentoringId) {
+                            setSelectedMentoringId(selectedMentoringId);
+                            openJuniorMentoringSpecModal();
+                          }
+                        }}
                         onClick={() => {
                           setModalType('junior');
                           setSelectedMentoringId(el.mentoringId);
+                          alert('z');
                         }}
                       />
                     )}

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -107,7 +107,7 @@ function TabBar() {
           });
       }
     });
-    if (activeTab === TAB.waiting && selectedMentoringId === 0) {
+    if (selectedMentoringId === 0) {
       applyBtnRef.current?.click();
     }
   }, [activeTab, prevMentoringInfoLength]);

--- a/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
+++ b/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
@@ -101,7 +101,7 @@ function STabBar() {
             console.error('Error fetching data:', error);
           });
       }
-      if (activeTab === TAB.waiting && selectedMentoringId === null) {
+      if (selectedMentoringId === null) {
         mentoringBtnRef?.current?.click();
       }
     });

--- a/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
+++ b/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import {
   TapStyle,
@@ -37,6 +37,7 @@ function STabBar() {
     setActiveTab(tabIndex);
   };
 
+  const mentoringBtnRef = useRef<HTMLButtonElement>(null);
   const { openModal: openAcceptMentoringModal } = useFullModal({
     modalType: 'accept-mentoring',
   });
@@ -100,6 +101,9 @@ function STabBar() {
             console.error('Error fetching data:', error);
           });
       }
+      if (activeTab === TAB.waiting && prevMentoringInfoLength === 0) {
+        mentoringBtnRef?.current?.click();
+      }
     });
   }, [activeTab, prevMentoringInfoLength]);
 
@@ -113,16 +117,22 @@ function STabBar() {
                 <MentoringApply data={el} />
                 {activeTab === TAB.waiting || activeTab === TAB.expected ? (
                   <ModalBtn
+                    ref={mentoringBtnRef}
                     type="seniorShow"
                     btnText={
                       activeTab === TAB.waiting
                         ? '신청서 보고 수락하기'
                         : '신청서 보기'
                     }
-                    modalHandler={openSeniorMentoringSpecModal}
+                    modalHandler={() => {
+                      router.push('/senior/mentoring');
+                    }}
                     onClick={() => {
                       setModalType('senior');
                       setSelectedMentoringId(el.mentoringId);
+                      if (selectedMentoringId) {
+                        openSeniorMentoringSpecModal();
+                      }
                     }}
                   />
                 ) : (

--- a/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
+++ b/src/components/Bar/TapBar/SeniorTab/STabBar.tsx
@@ -101,7 +101,7 @@ function STabBar() {
             console.error('Error fetching data:', error);
           });
       }
-      if (activeTab === TAB.waiting && prevMentoringInfoLength === 0) {
+      if (activeTab === TAB.waiting && selectedMentoringId === null) {
         mentoringBtnRef?.current?.click();
       }
     });

--- a/src/components/Button/ModalBtn/ModalBtn.tsx
+++ b/src/components/Button/ModalBtn/ModalBtn.tsx
@@ -1,3 +1,4 @@
+import React, { forwardRef } from 'react';
 import { ModalBtnProps } from '@/types/button/modalBtn';
 import {
   StyledModalBtn,
@@ -7,7 +8,8 @@ import {
 } from './ModalBtn.styled';
 import Image from 'next/image';
 import down from '../../../../public/arrow-down-gray.png';
-function ModalBtn(props: ModalBtnProps) {
+
+const ModalBtn = forwardRef<HTMLButtonElement, ModalBtnProps>((props, ref) => {
   const handleClick = () => {
     props.modalHandler();
     if (props.cancelModalHandler) {
@@ -19,46 +21,28 @@ function ModalBtn(props: ModalBtnProps) {
   return (
     <>
       {props.type === 'show' && (
-        <StyledSModalBtn
-          onClick={() => {
-            handleClick();
-          }}
-        >
+        <StyledSModalBtn ref={ref} onClick={handleClick}>
           {props.btnText}
         </StyledSModalBtn>
       )}
       {props.type === 'seniorShow' && (
-        <StyledMSBtn
-          onClick={() => {
-            handleClick();
-          }}
-        >
+        <StyledMSBtn ref={ref} onClick={handleClick}>
           {props.btnText}
         </StyledMSBtn>
       )}
       {props.type === 'seniorInfo' && (
-        <SInfoBtn
-          $isGet={props.$isGet}
-          onClick={() => {
-            handleClick();
-          }}
-        >
+        <SInfoBtn ref={ref} $isGet={props.$isGet} onClick={handleClick}>
           {props.btnText}
         </SInfoBtn>
       )}
       {props.type === 'bankInfo' && (
-        <SInfoBtn
-          $isGet={props.$isGet}
-          onClick={() => {
-            handleClick();
-          }}
-        >
+        <SInfoBtn ref={ref} $isGet={props.$isGet} onClick={handleClick}>
           {props.btnText}
           <Image src={down} alt="down" width={40} height={40} />
         </SInfoBtn>
       )}
     </>
   );
-}
+});
 
 export default ModalBtn;

--- a/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
+++ b/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
@@ -103,6 +103,7 @@ function MentoringSpec(props: ModalMentoringProps) {
               cancelModalHandler={() => {
                 if (props.cancelModalHandler) {
                   cancelMyMentoring(props.mentoringId);
+
                   props.cancelModalHandler();
                 }
               }}

--- a/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
+++ b/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
@@ -34,6 +34,8 @@ import { activeTabAtom } from '@/stores/tap';
 import { TAB } from '@/constants/tab/ctap';
 import { useRouter } from 'next/navigation';
 import Spinner from '@/components/Spinner';
+import { ErrorBoundary } from 'react-error-boundary';
+import { MentoringTabError } from '../error';
 
 function MentoringSpec(props: ModalMentoringProps) {
   const { getAccessToken, getUserType, removeTokens } = useAuth();
@@ -69,106 +71,108 @@ function MentoringSpec(props: ModalMentoringProps) {
   });
 
   return (
-    <Suspense fallback={<Spinner />}>
-      <ModalMentoringBackground>
-        <MMTop>
-          <div id="header-text">멘토링 신청서</div>
-          <div id="img">
-            <Image
-              id="x-icon"
-              src={x_icon}
-              alt="계정 수정 모달 닫기 버튼"
-              width={24}
-              height={24}
-              style={{}}
-              onClick={props.modalHandler}
-            />
-          </div>
-        </MMTop>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            padding: '1rem',
-          }}
-        >
-          <MNick>
-            {myApplyMentoringList?.nickName}
-            <Color>&nbsp;에게 보낸 신청서</Color>
-          </MNick>
-          {activeTab === TAB.waiting ? (
-            <ApplyCancleBtn
-              kind="jcancel"
-              btnText={'취소하기'}
-              cancelModalHandler={() => {
-                if (props.cancelModalHandler) {
-                  cancelMyMentoring(props.mentoringId);
+    <ErrorBoundary fallback={<MentoringTabError />}>
+      <Suspense fallback={<Spinner />}>
+        <ModalMentoringBackground>
+          <MMTop>
+            <div id="header-text">멘토링 신청서</div>
+            <div id="img">
+              <Image
+                id="x-icon"
+                src={x_icon}
+                alt="계정 수정 모달 닫기 버튼"
+                width={24}
+                height={24}
+                style={{}}
+                onClick={props.modalHandler}
+              />
+            </div>
+          </MMTop>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              padding: '1rem',
+            }}
+          >
+            <MNick>
+              {myApplyMentoringList?.nickName}
+              <Color>&nbsp;에게 보낸 신청서</Color>
+            </MNick>
+            {activeTab === TAB.waiting ? (
+              <ApplyCancleBtn
+                kind="jcancel"
+                btnText={'취소하기'}
+                cancelModalHandler={() => {
+                  if (props.cancelModalHandler) {
+                    cancelMyMentoring(props.mentoringId);
 
-                  props.cancelModalHandler();
-                }
-              }}
-              // modalHandler={props.modalHandler}
-              mentoringId={props.mentoringId}
-            />
-          ) : (
-            ''
-          )}
-        </div>
-        <MApplyBox>
-          <ConfirmContent>
-            <ConfirmProfile
-              src={
-                myApplyMentoringList?.profile
-                  ? myApplyMentoringList.profile
-                  : '/user.png'
-              }
-            ></ConfirmProfile>
-            <ConfirmInfo>
-              <ConfirmTitle>
-                {myApplyMentoringList?.nickName}&nbsp;
-                {userType === 'senior' ? '후배와 멘토링' : '선배와 멘토링'}
-              </ConfirmTitle>
-              {userType === 'junior' && (
-                <>
-                  <UserInfo>
-                    {myApplyMentoringList?.postgradu} :
-                    {myApplyMentoringList?.major}
-                    <br />
-                    {myApplyMentoringList?.lab}
-                  </UserInfo>
-                </>
-              )}
-            </ConfirmInfo>
-          </ConfirmContent>
-        </MApplyBox>
-        <div style={{ display: 'flex', padding: '1.56rem 1rem' }}>
-          <MMainFont>신청 일정&nbsp;</MMainFont>
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <MsubFont>3개의 일정 중 하나로 확정 됩니다</MsubFont>
+                    props.cancelModalHandler();
+                  }
+                }}
+                // modalHandler={props.modalHandler}
+                mentoringId={props.mentoringId}
+              />
+            ) : (
+              ''
+            )}
           </div>
-        </div>
-        <div>
-          {myApplyMentoringList?.dates?.map((date, index) => (
-            <TextToggleButton key={index} text={formatTime(date)} />
-          ))}
-        </div>
-        <Mmargin>
-          <MMainFont>멘토링 주제</MMainFont>
-        </Mmargin>
-        <div>
-          <TextToggleButton text={myApplyMentoringList?.topic ?? ''} />
-        </div>
-        <Mmargin>
-          <MMainFont>사전 질문</MMainFont>
-        </Mmargin>
-        <div>
-          <TextToggleButton text={myApplyMentoringList?.question ?? ''} />
-        </div>
-        <div style={{ marginBottom: '7rem' }}>
-          <ModalClose onClick={props.modalHandler}>확인 완료</ModalClose>
-        </div>
-      </ModalMentoringBackground>
-    </Suspense>
+          <MApplyBox>
+            <ConfirmContent>
+              <ConfirmProfile
+                src={
+                  myApplyMentoringList?.profile
+                    ? myApplyMentoringList.profile
+                    : '/user.png'
+                }
+              ></ConfirmProfile>
+              <ConfirmInfo>
+                <ConfirmTitle>
+                  {myApplyMentoringList?.nickName}&nbsp;
+                  {userType === 'senior' ? '후배와 멘토링' : '선배와 멘토링'}
+                </ConfirmTitle>
+                {userType === 'junior' && (
+                  <>
+                    <UserInfo>
+                      {myApplyMentoringList?.postgradu} :
+                      {myApplyMentoringList?.major}
+                      <br />
+                      {myApplyMentoringList?.lab}
+                    </UserInfo>
+                  </>
+                )}
+              </ConfirmInfo>
+            </ConfirmContent>
+          </MApplyBox>
+          <div style={{ display: 'flex', padding: '1.56rem 1rem' }}>
+            <MMainFont>신청 일정&nbsp;</MMainFont>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <MsubFont>3개의 일정 중 하나로 확정 됩니다</MsubFont>
+            </div>
+          </div>
+          <div>
+            {myApplyMentoringList?.dates?.map((date, index) => (
+              <TextToggleButton key={index} text={formatTime(date)} />
+            ))}
+          </div>
+          <Mmargin>
+            <MMainFont>멘토링 주제</MMainFont>
+          </Mmargin>
+          <div>
+            <TextToggleButton text={myApplyMentoringList?.topic ?? ''} />
+          </div>
+          <Mmargin>
+            <MMainFont>사전 질문</MMainFont>
+          </Mmargin>
+          <div>
+            <TextToggleButton text={myApplyMentoringList?.question ?? ''} />
+          </div>
+          <div style={{ marginBottom: '7rem' }}>
+            <ModalClose onClick={props.modalHandler}>확인 완료</ModalClose>
+          </div>
+        </ModalMentoringBackground>
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
+++ b/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
@@ -1,14 +1,14 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import useAuth from '@/hooks/useAuth';
-import axios from 'axios';
-import useModal from '@/hooks/useModal';
+
 import { MentoringSpecData } from '@/types/mentoring/mentoring';
 import TextToggleButton from '../../../TextToggleButton/TextToggleButton';
-import MentoringApply from '../../MentoringApply/MentoringApply';
+
 import { ModalMentoringProps } from '@/types/modal/mentoringDetail';
 import Image from 'next/image';
 import x_icon from '../../../../../public/x.png';
+import { useCancelMyMentoring } from '@/hooks/mutations/useCancelMyMentoring';
 import {
   ModalMentoringBackground,
   ModalClose,
@@ -27,18 +27,21 @@ import {
   MMTop,
 } from './MentoringSpec.styled';
 
+import { useGetMyApplyMentoringListQuery } from '@/hooks/query/useGetMyApplyMentoringList';
 import ApplyCancleBtn from '../../../Button/ApplyCancleBtn/ApplyCancleBtn';
 import { useAtom } from 'jotai';
 import { activeTabAtom } from '@/stores/tap';
 import { TAB } from '@/constants/tab/ctap';
 import { useRouter } from 'next/navigation';
-import findExCode from '@/utils/findExCode';
+import Spinner from '@/components/Spinner';
+
 function MentoringSpec(props: ModalMentoringProps) {
   const { getAccessToken, getUserType, removeTokens } = useAuth();
-  const [data, setData] = useState<MentoringSpecData | null>(null);
+
   const userType = getUserType();
   const router = useRouter();
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
+  const { mutate: cancelMyMentoring } = useCancelMyMentoring();
 
   const formatTime = (time: string) => {
     if (!time) return '';
@@ -61,127 +64,110 @@ function MentoringSpec(props: ModalMentoringProps) {
     } else return '';
   };
 
-  useEffect(() => {
-    if (props.mentoringId !== 0) {
-      getAccessToken().then((Token) => {
-        if (Token) {
-          const headers = {
-            Authorization: `Bearer ${Token}`,
-          };
-          axios
-            .get(
-              `${process.env.NEXT_PUBLIC_SERVER_URL}/mentoring/me/${props.mentoringId}`,
-              {
-                headers,
-              },
-            )
-            .then((response) => {
-              if (findExCode(response.data.code)) {
-                removeTokens();
-                location.reload();
-                return;
-              }
+  const { data: myApplyMentoringList } = useGetMyApplyMentoringListQuery({
+    mentoringId: props.mentoringId,
+  });
 
-              setData(response.data.data);
-            })
-            .catch((error) => {
-              console.error('Error fetching data:', error);
-            });
-        }
-      });
-    }
-  }, []);
   return (
-    <ModalMentoringBackground>
-      <MMTop>
-        <div id="header-text">멘토링 신청서</div>
-        <div id="img">
-          <Image
-            id="x-icon"
-            src={x_icon}
-            alt="계정 수정 모달 닫기 버튼"
-            width={24}
-            height={24}
-            style={{}}
-            onClick={props.modalHandler}
-          />
+    <Suspense fallback={<Spinner />}>
+      <ModalMentoringBackground>
+        <MMTop>
+          <div id="header-text">멘토링 신청서</div>
+          <div id="img">
+            <Image
+              id="x-icon"
+              src={x_icon}
+              alt="계정 수정 모달 닫기 버튼"
+              width={24}
+              height={24}
+              style={{}}
+              onClick={props.modalHandler}
+            />
+          </div>
+        </MMTop>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            padding: '1rem',
+          }}
+        >
+          <MNick>
+            {myApplyMentoringList?.nickName}
+            <Color>&nbsp;에게 보낸 신청서</Color>
+          </MNick>
+          {activeTab === TAB.waiting ? (
+            <ApplyCancleBtn
+              kind="jcancel"
+              btnText={'취소하기'}
+              cancelModalHandler={() => {
+                if (props.cancelModalHandler) {
+                  cancelMyMentoring(props.mentoringId);
+                  props.cancelModalHandler();
+                }
+              }}
+              // modalHandler={props.modalHandler}
+              mentoringId={props.mentoringId}
+            />
+          ) : (
+            ''
+          )}
         </div>
-      </MMTop>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: '1rem',
-        }}
-      >
-        <MNick>
-          {data ? data.nickName : ''}
-          <Color>&nbsp;에게 보낸 신청서</Color>
-        </MNick>
-        {activeTab === TAB.waiting ? (
-          <ApplyCancleBtn
-            kind="jcancel"
-            btnText={'취소하기'}
-            cancelModalHandler={props.cancelModalHandler}
-            // modalHandler={props.modalHandler}
-            mentoringId={props.mentoringId}
-          />
-        ) : (
-          ''
-        )}
-      </div>
-      <MApplyBox>
-        <ConfirmContent>
-          <ConfirmProfile
-            src={data ? data.profile : '/user.png'}
-          ></ConfirmProfile>
-          <ConfirmInfo>
-            <ConfirmTitle>
-              {data ? data.nickName : ''}&nbsp;
-              {userType === 'senior' ? '후배와 멘토링' : '선배와 멘토링'}
-            </ConfirmTitle>
-            {userType === 'junior' && (
-              <>
-                <UserInfo>
-                  {data ? data.postgradu : ''} {data ? data.major : ''}
-                  <br />
-                  {data ? data.lab : ''}
-                </UserInfo>
-              </>
-            )}
-          </ConfirmInfo>
-        </ConfirmContent>
-      </MApplyBox>
-      <div style={{ display: 'flex', padding: '1.56rem 1rem' }}>
-        <MMainFont>신청 일정&nbsp;</MMainFont>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <MsubFont>3개의 일정 중 하나로 확정 됩니다</MsubFont>
+        <MApplyBox>
+          <ConfirmContent>
+            <ConfirmProfile
+              src={
+                myApplyMentoringList?.profile
+                  ? myApplyMentoringList.profile
+                  : '/user.png'
+              }
+            ></ConfirmProfile>
+            <ConfirmInfo>
+              <ConfirmTitle>
+                {myApplyMentoringList?.nickName}&nbsp;
+                {userType === 'senior' ? '후배와 멘토링' : '선배와 멘토링'}
+              </ConfirmTitle>
+              {userType === 'junior' && (
+                <>
+                  <UserInfo>
+                    {myApplyMentoringList?.postgradu} :
+                    {myApplyMentoringList?.major}
+                    <br />
+                    {myApplyMentoringList?.lab}
+                  </UserInfo>
+                </>
+              )}
+            </ConfirmInfo>
+          </ConfirmContent>
+        </MApplyBox>
+        <div style={{ display: 'flex', padding: '1.56rem 1rem' }}>
+          <MMainFont>신청 일정&nbsp;</MMainFont>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <MsubFont>3개의 일정 중 하나로 확정 됩니다</MsubFont>
+          </div>
         </div>
-      </div>
-      <div>
-        {data &&
-          data.dates &&
-          data.dates.length > 0 &&
-          data.dates.map((date, index) => (
+        <div>
+          {myApplyMentoringList?.dates?.map((date, index) => (
             <TextToggleButton key={index} text={formatTime(date)} />
           ))}
-      </div>
-      <Mmargin>
-        <MMainFont>멘토링 주제</MMainFont>
-      </Mmargin>
-      <div>
-        <TextToggleButton text={data ? data.topic : ''} />
-      </div>
-      <Mmargin>
-        <MMainFont>사전 질문</MMainFont>
-      </Mmargin>
-      <div>
-        <TextToggleButton text={data ? data.question : ''} />
-      </div>
-      <div style={{ marginBottom: '7rem' }}>
-        <ModalClose onClick={props.modalHandler}>확인 완료</ModalClose>
-      </div>
-    </ModalMentoringBackground>
+        </div>
+        <Mmargin>
+          <MMainFont>멘토링 주제</MMainFont>
+        </Mmargin>
+        <div>
+          <TextToggleButton text={myApplyMentoringList?.topic ?? ''} />
+        </div>
+        <Mmargin>
+          <MMainFont>사전 질문</MMainFont>
+        </Mmargin>
+        <div>
+          <TextToggleButton text={myApplyMentoringList?.question ?? ''} />
+        </div>
+        <div style={{ marginBottom: '7rem' }}>
+          <ModalClose onClick={props.modalHandler}>확인 완료</ModalClose>
+        </div>
+      </ModalMentoringBackground>
+    </Suspense>
   );
 }
 

--- a/src/components/Mentoring/MentoringSpec/SmentoringSpec/SmentoringSpec.tsx
+++ b/src/components/Mentoring/MentoringSpec/SmentoringSpec/SmentoringSpec.tsx
@@ -129,9 +129,7 @@ function SmentoringSpec(props: ModalMentoringSProps) {
           );
           const responseData = await response.json();
           setIsAccount(responseData.data);
-          if (props.acceptModalHandler) {
-            props.acceptModalHandler();
-          }
+
           props.modalHandler();
         }
       });
@@ -222,7 +220,7 @@ function SmentoringSpec(props: ModalMentoringSProps) {
               kind="spec"
               btnText={'거절'}
               cancelModalHandler={props.cancelModalHandler}
-              mentoringId={props.mentoringId}
+              mentoringId={props.mentoringId as number}
             />
             {date ? (
               <ModalClose onClick={acceptMentoring}>멘토링 수락</ModalClose>

--- a/src/components/Mentoring/MentoringSpec/error.tsx
+++ b/src/components/Mentoring/MentoringSpec/error.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect } from 'react';
+import styled from 'styled-components';
+import { useRouter } from 'next/navigation';
+
+const ErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 50px;
+  justify-content: center;
+  height: 100vh;
+  text-align: center;
+`;
+
+const ErrorMessage = styled.h1`
+  font-size: 24px;
+  margin-bottom: 20px;
+`;
+
+const RetryButton = styled.button`
+  padding: 10px 20px;
+  font-size: 16px;
+  background-color: #2fc4b2;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #2fc4b2;
+  }
+`;
+
+export function MentoringTabError({
+  error,
+  reset,
+}: {
+  error?: Error & { digest?: string };
+  reset?: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <ErrorContainer>
+      <ErrorMessage>
+        멘토링 정보를 불러오는 중 오류가 발생했습니다.
+      </ErrorMessage>
+
+      <RetryButton onClick={() => router.push('/')}>
+        홈으로 돌아가기
+      </RetryButton>
+    </ErrorContainer>
+  );
+}

--- a/src/components/Mentoring/SmentoringCancel/SmentoringCancel.styled.ts
+++ b/src/components/Mentoring/SmentoringCancel/SmentoringCancel.styled.ts
@@ -46,7 +46,7 @@ export const SModalMentoringBackground = styled.div`
   transform: translate(-50%, -50%);
   width: 20.5rem;
   height: 28.5rem;
-  z-index: 2;
+
   background-color: white;
 
   @media (min-width: 360px) and (max-width: 600px) {

--- a/src/components/Modal/FullModal/FullModal.tsx
+++ b/src/components/Modal/FullModal/FullModal.tsx
@@ -36,7 +36,7 @@ function FullModal(props: FullModalProps) {
               <MentoringSpec
                 modalHandler={props.modalHandler}
                 cancelModalHandler={props.cancelModalHandler || (() => {})}
-                mentoringId={props.mentoringId || 0}
+                mentoringId={props.selectedMentoringId || 0}
               />
             );
           case 'profile-modify':

--- a/src/components/Modal/FullModal/FullModal.tsx
+++ b/src/components/Modal/FullModal/FullModal.tsx
@@ -36,7 +36,7 @@ function FullModal(props: FullModalProps) {
               <MentoringSpec
                 modalHandler={props.modalHandler}
                 cancelModalHandler={props.cancelModalHandler || (() => {})}
-                mentoringId={props.selectedMentoringId || 0}
+                mentoringId={props.selectedMentoringId as number}
               />
             );
           case 'profile-modify':

--- a/src/hooks/mutations/useCancelMyMentoring.ts
+++ b/src/hooks/mutations/useCancelMyMentoring.ts
@@ -1,0 +1,10 @@
+import { cancleMentoring } from '@/api/mentoring/cancelMentoring';
+import { useMutation } from '@tanstack/react-query';
+export const useCancelMyMentoring = () => {
+  return useMutation({
+    mutationFn: cancleMentoring,
+    onSuccess: () => {
+      alert('멘토링 취소를 완료하였습니다!');
+    },
+  });
+};

--- a/src/hooks/mutations/useConfirmMyMentoring.ts
+++ b/src/hooks/mutations/useConfirmMyMentoring.ts
@@ -1,0 +1,8 @@
+import { confirmMentoring } from '@/api/mentoring/confirmMentoring';
+import { useMutation } from '@tanstack/react-query';
+
+export const useConfirmMyMentoring = () => {
+  return useMutation({
+    mutationFn: confirmMentoring,
+  });
+};

--- a/src/hooks/mutations/useConfirmSeniorMentoring.ts
+++ b/src/hooks/mutations/useConfirmSeniorMentoring.ts
@@ -1,0 +1,8 @@
+import { confirmSeniorMentoring } from '@/api/mentoring/\bconfirmSeniorMentoring';
+import { useMutation } from '@tanstack/react-query';
+
+export const useConfirmSeniorMentoring = () => {
+  return useMutation({
+    mutationFn: confirmSeniorMentoring,
+  });
+};

--- a/src/hooks/query/useGetMyApplyMentoringList.ts
+++ b/src/hooks/query/useGetMyApplyMentoringList.ts
@@ -1,0 +1,15 @@
+import { getMyApplyMentoringList } from '@/api/mentoring/getMyApplyMentoringList';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetMyApplyMentoringListQuery = ({
+  mentoringId,
+}: {
+  mentoringId: number;
+}) => {
+  return useQuery({
+    suspense: true,
+    useErrorBoundary: true,
+    queryFn: () => getMyApplyMentoringList(mentoringId),
+    queryKey: [`/getMyApplyMentoringList/${mentoringId}`],
+  });
+};

--- a/src/hooks/query/useGetSeniorMentoringList.ts
+++ b/src/hooks/query/useGetSeniorMentoringList.ts
@@ -1,0 +1,17 @@
+import { getSeniorMentoringList } from '@/api/mentoring/getSeniorMentoringList';
+
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetSeniorMentoringListQuery = ({
+  mentoringId,
+}: {
+  mentoringId: number;
+}) => {
+  return useQuery({
+    queryFn: () => getSeniorMentoringList({ mentoringId }),
+    queryKey: [`/getSeniorMentoringList/${mentoringId}`],
+    enabled: mentoringId !== 0,
+    useErrorBoundary: true,
+    suspense: true,
+  });
+};

--- a/src/hooks/useDimmedModal.tsx
+++ b/src/hooks/useDimmedModal.tsx
@@ -2,13 +2,18 @@ import DimmedModal from '@/components/Modal/DimmedModal';
 
 import { DimmedModalProps } from '@/types/modal/dimmed';
 import { overlay } from 'overlay-kit';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface UseDimmedModalProps extends DimmedModalProps {
   overlayId?: string;
 }
 const useDimmedModal = ({ ...props }: Partial<UseDimmedModalProps>) => {
   const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    window.addEventListener('popstate', () => {
+      overlay.unmountAll();
+    });
+  }, []);
 
   const openModal = () => {
     setIsOpen(true);

--- a/src/hooks/useFullModal.tsx
+++ b/src/hooks/useFullModal.tsx
@@ -1,16 +1,51 @@
 import FullModal from '@/components/Modal/FullModal';
 import { FullModalProps } from '@/types/modal/full';
 import { overlay } from 'overlay-kit';
-import { useState } from 'react';
+
+import { useState, useEffect } from 'react';
 
 interface UseFullModalProps extends FullModalProps {
   overlayId?: string;
 }
 const useFullModal = ({ ...props }: Partial<UseFullModalProps>) => {
   const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    window.addEventListener('popstate', () => {
+      overlay.unmountAll();
+    });
+  }, []);
 
+  const openModalAsync = async () => {
+    setIsOpen(true);
+    overlay.openAsync(
+      async ({ unmount }) => {
+        return (
+          <FullModal
+            {...props}
+            modalType={props?.modalType ?? 'best-case'}
+            modalHandler={() => {
+              if (props.modalHandler) {
+                props.modalHandler();
+              }
+              closeModal(unmount);
+            }}
+            cancelModalHandler={() => {
+              if (props.cancelModalHandler) {
+                props.cancelModalHandler();
+              }
+              closeModal(unmount);
+            }}
+          />
+        );
+      },
+      {
+        overlayId: props.overlayId ?? '',
+      },
+    );
+  };
   const openModal = () => {
     setIsOpen(true);
+
     overlay.open(
       ({ unmount }) => {
         return (
@@ -51,7 +86,7 @@ const useFullModal = ({ ...props }: Partial<UseFullModalProps>) => {
     }
   };
 
-  return { openModal, closeModal, toggleModal, isOpen };
+  return { openModal, closeModal, toggleModal, isOpen, openModalAsync };
 };
 
 export default useFullModal;

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -54,6 +54,12 @@ const useKakaoLogin = () => {
           return;
         }
 
+        if (kakaoAuthFetchRes.code === 'AU205') {
+          localStorage.setItem('socialId', kakaoAuthFetchRes.data.socialId);
+          router.push('/signup/select');
+          return;
+        }
+
         if (findExCode(kakaoAuthFetchRes.code)) {
           alert('탈퇴 후 15일에서 30일 사이에는 로그인이 불가능합니다.');
           router.push('/');

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -3,4 +3,4 @@ import { atom } from 'jotai';
 export const accessTokenAtom = atom<string>('');
 export const accessExpireAtom = atom<Date>(new Date());
 
-export const mentoringIdAtom = atom<string>('');
+export const mentoringIdAtom = atom<number>(0);

--- a/src/types/modal/mentoringDetail.ts
+++ b/src/types/modal/mentoringDetail.ts
@@ -12,7 +12,7 @@ export interface ModalMentoringSProps {
   modalHandler: () => void;
   cancelModalHandler: () => void;
   acceptModalHandler: () => void;
-  mentoringId: number;
+  mentoringId: number | undefined;
   onClick?: () => void;
 }
 


### PR DESCRIPTION
## 🦝 PR 요약

최종 배포 전 QA 오류사항들 반영

## ✨ PR 상세 내용

원준님이 정리해주신 QA목록들을 정리해 수정하였습니다. 총 다음의 문제들을 고쳐놓았어요

- 멘토링 상세보기에서 브라우저의 뒤로가기를 누르면 나가지 않고 배너가 나옴
해당 부분은 overlay-kit를 쓰는 모달부분에서 공통적으로 나타나는 문제였는데요.. 모달을 닫지 않고 뒤로가기를 누를 떄의 케이스를 고려하지 않았더라고요!..
따라서 브라우저의 popState이벤트가 있을 때 모든 모달이 닫히게 처리를 해주었습니다.

- 계정 설정에서 기존 휴대폰 번호 노출 필요
요 부분은 단순히 데이터를 받아오고 정보 갱신을 안해주고 있더라고요..(제가 고친 부분ㅇ이었네요..죄송..)

- 선배가 멘토링 수락시, 바깥 페이지로 나가지지 않음 (해당 페이지에서 대기)
해당 부분은 멘토링 수락 시, 다시 페이지가 로드되도록 바꿔놨습니다. 동시에 쿼리와 뮤테이션을 쓰도록 바꿔놓았어요

- 멘토링 신청, 신청받은 멘토링 상세보기 
해당 부분은 다음과 같이 `mentoringId`를 모달 훅에 초기에 넣어두었는데, (아래와 같은 형태)

```tsx
const {
  openModal: openJuniorMentoringSpecModal,
  closeModal: closeJunuiorMentoringSpec,
} = useFullModal({
  modalType: 'junior-mentoring-spec',
  selectedMentoringId: selectedMentoringId,
});

<ModalBtn
  type={'show'}
  btnText={'내 신청서 보기'}
  modalHandler={() => {
    if (selectedMentoringId) {
      setSelectedMentoringId(selectedMentoringId);
      if (selectedMentoringId !== 0) {
        openJuniorMentoringSpecModal();
      }
    }
  }}
  onClick={() => {
    setModalType('junior');
    setSelectedMentoringId(el.mentoringId);
  }}
/>
```

저 selectedMentoringId가 자꾸 정해둔 초기값으로 들어가더라고요!!.. 그래서 결국 onClick시에는 바로 state가 갱신이 안되는 점을 고치지 못해 ref로 관리하도록 수정하였어요!

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
