### PR TITLE
RAC 456 : Refactor 선배회원 거절 실패, 성공 모달 추가 및 후배회원 취소하기 모달 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --check --ignore-path .gitignore .",
-    "format:fix": "prettier --write --ignore-path .gitignore ."
+    "format:fix": "prettier --write --ignore-path .gitignore .",
+    "lint:fix": "next lint --fix"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/src/api/senior/updateSeniorProfile.ts
+++ b/src/api/senior/updateSeniorProfile.ts
@@ -1,0 +1,39 @@
+import { TimeObj } from '@/types/scheduler/scheduler';
+import { withAuthInstance } from '../api';
+import { ResponseModel } from '../model';
+
+interface UpdateSeniorProfileResponse extends ResponseModel {
+  data: {
+    seniorId: number;
+  };
+}
+
+interface UpdateSeniorProfileRequest {
+  info: string;
+  target: string;
+  times: TimeObj[];
+  oneLiner: string;
+}
+
+export const updateSeniorProfile = async ({
+  info,
+  target,
+  times,
+  oneLiner,
+}: UpdateSeniorProfileRequest) => {
+  try {
+    return (
+      await withAuthInstance.patch<UpdateSeniorProfileResponse>(
+        '/senior/profile',
+        {
+          info,
+          target,
+          times,
+          oneLiner,
+        },
+      )
+    ).data;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/app/add-chat-link/page.tsx
+++ b/src/app/add-chat-link/page.tsx
@@ -10,8 +10,6 @@ import {
 import useAuth from '@/hooks/useAuth';
 import { option } from '@/stores/condition';
 import {
-  mySeniorId,
-  sAbleTime,
   sChatLink,
   sFieldAtom,
   sKeywordAtom,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import Providers from '@/components/Provider/providers';
 import StyledComponentsRegistry from '@/lib/registry';
 import GTMAnalytics from '@/components/GA/GTM';
 import GoogleAnalytics from '@/components/GA/GA';
-import { Viewport } from 'next/dist/lib/metadata/types/extra-types';
 import { SERVICE_METADATA } from '@/constants/meta/metaData';
 import OverlayKitProvider from '@/lib/overlay';
 

--- a/src/app/mypage/salary/page.tsx
+++ b/src/app/mypage/salary/page.tsx
@@ -9,7 +9,6 @@ import { TAB, STAB_STATE } from '@/constants/tab/ctap';
 import SalaryProfile from '@/components/Profile/salaryProfile/salaryProfile';
 import BackHeader from '@/components/Header/BackHeader';
 import { useRouter } from 'next/navigation';
-import findExCode from '@/utils/findExCode';
 
 function SalaryPage() {
   const { getAccessToken, getUserType, removeTokens } = useAuth();

--- a/src/app/signup/select/common-info/senior-info/field/page.tsx
+++ b/src/app/signup/select/common-info/senior-info/field/page.tsx
@@ -1,18 +1,6 @@
 'use client';
 import RiseUpModal from '@/components/Modal/RiseUpModal';
-import useModal from '@/hooks/useModal';
-import { option } from '@/stores/condition';
-import {
-  photoUrlAtom,
-  sFieldAtom,
-  sKeywordAtom,
-  sLabAtom,
-  sMajorAtom,
-  sPostGraduAtom,
-  sProfessorAtom,
-} from '@/stores/senior';
-import { changeNickname, phoneNum } from '@/stores/signup';
-import { ModalType } from '@/types/modal/riseUp';
+import { sFieldAtom, sKeywordAtom } from '@/stores/senior';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -26,18 +14,10 @@ import { SENIOR_FIELD } from '@/constants/signup/senior';
 import { overlay } from 'overlay-kit';
 
 function SeniorInfoPage() {
-  const [emptyPart, setEmptyPart] = useState('');
   const [flag, setFlag] = useState(false);
   const [ableSubmit, setAbleSubmit] = useState(false);
 
   const router = useRouter();
-  const {
-    getAccessToken,
-    setAccessToken,
-    setRefreshToken,
-    setUserType,
-    removeTokens,
-  } = useAuth();
   const [socialId, setSocialId] = useState<number | null>(null);
 
   const sField = useAtomValue(sFieldAtom);

--- a/src/components/Bar/FieldTapBar/FieldTapBar.tsx
+++ b/src/components/Bar/FieldTapBar/FieldTapBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { ComponentPropsWithoutRef } from 'react';
+import React from 'react';
 import { TapStyle } from './FieldTapBar.styled';
 import { sftapType } from '@/types/tap/tap';
 import { sfactiveTabAtom } from '@/stores/tap';

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -17,9 +17,8 @@ import { TAB } from '@/constants/tab/ctap';
 import MentoringApply from '@/components/Mentoring/MentoringApply/MentoringApply';
 import ModalBtn from '@/components/Button/ModalBtn';
 import useModal from '@/hooks/useModal';
+import useDimmedModal from '@/hooks/useDimmedModal';
 import { ModalMentoringType } from '@/types/modal/mentoringDetail';
-import { createPortal } from 'react-dom';
-import DimmedModal from '@/components/Modal/DimmedModal';
 
 import { useGetMyMentoringActiveTabQuery } from '@/hooks/query/useGetMyMentoringActiveTab';
 
@@ -51,20 +50,29 @@ function TabBar() {
   const handleTabClick = (tabIndex: tapType) => {
     setActiveTab(tabIndex);
   };
+  const [selectedMentoringId, setSelectedMentoringId] = useState<number>(0);
 
   const {
     modal: cancelModal,
     modalHandler: cancelModalHandler,
     portalElement: cancelPortalElement,
   } = useModal('junior-mentoring-cancel');
-  const [selectedMentoringId, setSelectedMentoringId] = useState<number>(0);
+
   const applyBtnRef = useRef<HTMLButtonElement>(null);
+
+  const { openModal: openJuniorMentoringCancelModal } = useDimmedModal({
+    modalType: 'juniorCancelMent',
+    mentoringId: selectedMentoringId ?? 0,
+    overlayId: 'openJuniorMentoringCancelModal',
+  });
+
   const {
     openModal: openJuniorMentoringSpecModal,
     closeModal: closeJunuiorMentoringSpec,
   } = useFullModal({
     modalType: 'junior-mentoring-spec',
     selectedMentoringId: selectedMentoringId,
+    cancelModalHandler: openJuniorMentoringCancelModal,
   });
 
   const JMCancel = useAtomValue(JMCancelAtom);
@@ -74,11 +82,13 @@ function TabBar() {
     if (JMCancel === true) {
       location.reload();
     }
+    setSelectedMentoringId(0);
   }, [activeTab]);
 
   useEffect(() => {
     if (selectedMentoringId !== 0) {
       openJuniorMentoringSpecModal();
+      setSelectedMentoringId(0);
     }
   }, [selectedMentoringId]);
 
@@ -202,17 +212,6 @@ function TabBar() {
           </div>
         </TabResult>
       </TabResultContainer>
-
-      {cancelModal && cancelPortalElement
-        ? createPortal(
-            <DimmedModal
-              modalType="juniorCancelMent"
-              modalHandler={cancelModalHandler}
-              mentoringId={selectedMentoringId || 0}
-            />,
-            cancelPortalElement,
-          )
-        : null}
     </div>
   );
 }

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -13,7 +13,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import { activeTabAtom } from '@/stores/tap';
 import { tapType } from '@/types/tap/tap';
 
-import { TAB, TAB_STATE } from '@/constants/tab/ctap';
+import { TAB } from '@/constants/tab/ctap';
 import MentoringApply from '@/components/Mentoring/MentoringApply/MentoringApply';
 import ModalBtn from '@/components/Button/ModalBtn';
 import useModal from '@/hooks/useModal';

--- a/src/components/Button/ApplyCancleBtn/ApplyCancleBtn.tsx
+++ b/src/components/Button/ApplyCancleBtn/ApplyCancleBtn.tsx
@@ -1,8 +1,6 @@
 'use client';
 import { CancleBtnProps } from '@/types/button/applyCancleBtn';
-import useModal from '@/hooks/useModal';
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import React from 'react';
 import { ApplyCancleBtnStyle, ACsenior } from './ApplyCancleBtn.styled';
 export default function ApplyCancleBtn(props: CancleBtnProps) {
   const handleClick = () => {

--- a/src/components/Button/ModalBtn/ModalBtn.tsx
+++ b/src/components/Button/ModalBtn/ModalBtn.tsx
@@ -1,11 +1,6 @@
 import React, { forwardRef } from 'react';
 import { ModalBtnProps } from '@/types/button/modalBtn';
-import {
-  StyledModalBtn,
-  StyledSModalBtn,
-  SInfoBtn,
-  StyledMSBtn,
-} from './ModalBtn.styled';
+import { StyledSModalBtn, SInfoBtn, StyledMSBtn } from './ModalBtn.styled';
 import Image from 'next/image';
 import down from '../../../../public/arrow-down-gray.png';
 

--- a/src/components/Content/AddTime/AddTime.tsx
+++ b/src/components/Content/AddTime/AddTime.tsx
@@ -16,7 +16,6 @@ import SingleValidator from '@/components/Validator/SingleValidator';
 import { useAtom } from 'jotai';
 import { sAbleTime } from '@/stores/senior';
 import { TimeObj } from '@/types/scheduler/scheduler';
-import ClickedBtn from '@/components/Button/ClickedBtn';
 import NextBtn from '@/components/Button/NextBtn';
 
 function AddTime({ modalHandler }: { modalHandler: () => void }) {

--- a/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
+++ b/src/components/Mentoring/MentoringSpec/JmentoringSpec/MentoringSpec.tsx
@@ -1,8 +1,7 @@
 'use client';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense } from 'react';
 import useAuth from '@/hooks/useAuth';
 
-import { MentoringSpecData } from '@/types/mentoring/mentoring';
 import TextToggleButton from '../../../TextToggleButton/TextToggleButton';
 
 import { ModalMentoringProps } from '@/types/modal/mentoringDetail';
@@ -23,7 +22,6 @@ import {
   ConfirmInfo,
   ConfirmTitle,
   UserInfo,
-  ConfirmState,
   MMTop,
 } from './MentoringSpec.styled';
 
@@ -38,10 +36,10 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { MentoringTabError } from '../error';
 
 function MentoringSpec(props: ModalMentoringProps) {
-  const { getAccessToken, getUserType, removeTokens } = useAuth();
+  const { getUserType } = useAuth();
 
   const userType = getUserType();
-  const router = useRouter();
+
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
   const { mutate: cancelMyMentoring } = useCancelMyMentoring();
 

--- a/src/components/Mentoring/SmentoringCancel/SmentoringCancel.tsx
+++ b/src/components/Mentoring/SmentoringCancel/SmentoringCancel.tsx
@@ -5,13 +5,8 @@ import { ModalMentoringProps } from '@/types/modal/mentoringDetail';
 import { SENIOR_MENTOR_CANCEL } from '@/constants/form/sMentoCanelForm';
 import CheckBox from '@/components/Checkbox';
 import { useAtom } from 'jotai';
-import {
-  SCEtc,
-  SMCancelAtom,
-  SMCancelSuccessAtom,
-  noTime,
-  notKnow,
-} from '@/stores/condition';
+import { SMCancelSuccessAtom } from '@/stores/condition';
+import { SCEtc, SMCancelAtom, noTime, notKnow } from '@/stores/condition';
 import Image from 'next/image';
 import x_icon from '../../../../public/x.png';
 import {
@@ -36,7 +31,7 @@ function SmentoringCancel(props: ModalMentoringProps) {
   const [SMCancel, setSMCancel] = useAtom(SMCancelAtom);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useAtom(SMCancelSuccessAtom);
+  const [_success, setSuccess] = useAtom(SMCancelSuccessAtom);
   const selected = time || know || etc;
   const [submittingText, setSubmittingText] = useState('');
 
@@ -96,6 +91,7 @@ function SmentoringCancel(props: ModalMentoringProps) {
           setIsSubmitting(false);
           if (response.data.code === 'MT201') {
             setSuccess(true);
+            setSMCancel(true);
             props.modalHandler();
             if (props.successHandler) {
               props.successHandler();
@@ -109,6 +105,8 @@ function SmentoringCancel(props: ModalMentoringProps) {
           }
         }
       } catch (error) {
+        props.modalHandler();
+        setSMCancel(false);
         console.error('Error cancelling mentoring:', error);
       }
     }, 1000);

--- a/src/components/Modal/DimmedModal/DimmedModal.tsx
+++ b/src/components/Modal/DimmedModal/DimmedModal.tsx
@@ -34,6 +34,7 @@ function DimmedModal(props: DimmedModalProps) {
             mentoringId={props.mentoringId || 0}
             modalHandler={props.modalHandler}
             successHandler={props.successHandler}
+            cancelModalHandler={props.infoHandler}
           />
         )}
         {props.modalType == 'juniorCancelMent' && (

--- a/src/components/Modal/NotSenior/NotSenior.tsx
+++ b/src/components/Modal/NotSenior/NotSenior.tsx
@@ -1,11 +1,10 @@
 'use client';
 import { NotSeniorProps } from '@/types/modal/mypage';
-import React, { useState } from 'react';
+import React from 'react';
 import x_icon from '../../../../public/x_gray.png';
 import Image from 'next/image';
-import Router, { useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { SENIOR_MODAL } from '@/constants/form/notSeniorForm';
-import { sAbleTime } from '@/stores/senior';
 import {
   NotSeniorBoxTop,
   NotSeniorMid,
@@ -15,9 +14,6 @@ import {
   NSBtn,
   NotSeniorContainer,
 } from './NotSenior.styled';
-import { useAtom } from 'jotai';
-import { userTypeAtom } from '@/stores/signup';
-
 function NotSenior(props: NotSeniorProps) {
   const xClick = () => {
     props.modalHandler();

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,7 +1,6 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Image from 'next/image';
-import warn from '../../../public/warn.png';
 import {
   ProfileBox,
   ProfileInfo,
@@ -12,13 +11,9 @@ import {
   ImageBox,
 } from './Profile.styled';
 import { ProfileProps } from '@/types/profile/profile';
-import SingleValidator from '../Validator/SingleValidator';
 import user_icon from '../../../public/user.png';
 
 function Profile(props: ProfileProps) {
-  const suggestModal = () => {
-    props.modalHandler();
-  };
   return (
     <ProfileBox>
       <ImageBox>

--- a/src/components/SingleForm/KeywordForm/KeywordForm.tsx
+++ b/src/components/SingleForm/KeywordForm/KeywordForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAtom, useSetAtom } from 'jotai';
 import {
   sKeywordAtom,
@@ -14,7 +14,6 @@ import {
 import { SELECT_KEYWORD_TEXT } from '@/constants/keyword/keyword';
 import SelectedBtn from '@/components/Button/SelectedBtn';
 import { useFormContext } from 'react-hook-form';
-import NextBtn from '@/components/Button/NextBtn';
 
 function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
   const {

--- a/src/components/SingleForm/KeywordForm/KeywordForm.tsx
+++ b/src/components/SingleForm/KeywordForm/KeywordForm.tsx
@@ -19,7 +19,6 @@ function KeywordForm({ clickHandler }: { clickHandler: () => void }) {
   const {
     register,
     watch,
-    setError,
     setValue,
     formState: { errors },
   } = useFormContext();

--- a/src/components/SingleForm/PhoneNumForm/PhoneNumForm.tsx
+++ b/src/components/SingleForm/PhoneNumForm/PhoneNumForm.tsx
@@ -35,14 +35,6 @@ function PhoneNumForm({ defaultValue }: { defaultValue?: string }) {
     }
   }, []);
 
-  useEffect(() => {
-    if (typeof errors.phoneNum?.message === 'undefined') {
-      setAvailability(true);
-    } else {
-      setAvailability(false);
-    }
-  }, [errors.phoneNum?.message]);
-
   return (
     <div>
       <div style={{ marginLeft: '0.75rem', marginTop: '1.5rem' }}>
@@ -69,6 +61,10 @@ function PhoneNumForm({ defaultValue }: { defaultValue?: string }) {
             placeholder="숫자만 입력"
             defaultValue={defaultValue || ''}
             {...register('phoneNum')}
+            onBlur={(e) => {
+              register('phoneNum').onBlur(e);
+              setAvailability(errors.phoneNum?.message ? false : true);
+            }}
           />
         </PhoneNumContainer>
       </div>

--- a/src/components/SingleForm/PhoneNumForm/PhoneNumForm.tsx
+++ b/src/components/SingleForm/PhoneNumForm/PhoneNumForm.tsx
@@ -1,14 +1,30 @@
 'use client';
 import SingleValidator from '@/components/Validator/SingleValidator';
 import { PhoneNumContainer, NumFont } from './PhoneNumForm.styled';
-import { useEffect, useState } from 'react';
-import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+import { useAtomValue, useAtom } from 'jotai';
 import { phoneNum, phoneNumValidation } from '@/stores/signup';
+import { phoneNumSchema } from './phoneNumSchema';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+interface FormData {
+  phoneNum: string;
+}
 
 function PhoneNumForm({ defaultValue }: { defaultValue?: string }) {
-  const [flag, setFlag] = useState(false); // 최초 입력 체크하는 flag
-  const [fullNum, setFullNum] = useAtom(phoneNum);
-  const [availability, setValidation] = useAtom(phoneNumValidation);
+  const fullNum = useAtomValue(phoneNum);
+  const [availability, setAvailability] = useAtom(phoneNumValidation);
+  const {
+    register,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: yupResolver(phoneNumSchema),
+    defaultValues: {
+      phoneNum: defaultValue ?? '',
+    },
+    mode: 'onBlur',
+  });
 
   useEffect(() => {
     if (fullNum) {
@@ -19,47 +35,26 @@ function PhoneNumForm({ defaultValue }: { defaultValue?: string }) {
     }
   }, []);
 
-  function checkPhoneNum(e: React.ChangeEvent<HTMLInputElement>) {
-    if (!flag) setFlag(true);
-
-    if (checkValidation(e.currentTarget.value)) {
-      setFlag(false);
-      setValidation(true);
+  useEffect(() => {
+    if (typeof errors.phoneNum?.message === 'undefined') {
+      setAvailability(true);
     } else {
-      setFlag(true);
-      setValidation(false);
+      setAvailability(false);
     }
-  }
-
-  function checkValidation(testStr: string) {
-    const numberPattern = /^[0-9]+$/;
-    if (!numberPattern.test(testStr)) {
-      return false;
-    }
-
-    if (testStr.length !== 11) {
-      return false;
-    }
-
-    if (testStr.substring(0, 3) !== '010') {
-      return false;
-    }
-
-    return true;
-  }
+  }, [errors.phoneNum?.message]);
 
   return (
     <div>
       <div style={{ marginLeft: '0.75rem', marginTop: '1.5rem' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <NumFont>휴대폰 번호</NumFont>
-          {flag && (
+          {errors.phoneNum?.message && (
             <SingleValidator
               textColor="#FF3347"
-              msg="올바르지 않은 휴대폰 번호입니다."
+              msg={errors.phoneNum.message}
             />
           )}
-          {!flag && availability && (
+          {typeof errors.phoneNum?.message === 'undefined' && availability && (
             <SingleValidator
               textColor="#00A0E1"
               msg="올바른 휴대폰 번호입니다."
@@ -73,14 +68,7 @@ function PhoneNumForm({ defaultValue }: { defaultValue?: string }) {
             className="phone-num-input"
             placeholder="숫자만 입력"
             defaultValue={defaultValue || ''}
-            maxLength={11}
-            onChange={(e) => {
-              setFullNum(e.currentTarget.value);
-              checkPhoneNum(e);
-            }}
-            // onBlur={(e) => {
-            //   checkPhoneNum(e);
-            // }}
+            {...register('phoneNum')}
           />
         </PhoneNumContainer>
       </div>

--- a/src/components/SingleForm/PhoneNumForm/phoneNumSchema.ts
+++ b/src/components/SingleForm/PhoneNumForm/phoneNumSchema.ts
@@ -1,0 +1,16 @@
+import * as yup from 'yup';
+
+export const phoneNumSchema = yup.object({
+  phoneNum: yup
+    .string()
+    .required('휴대폰 번호를 입력해 주세요.')
+    .matches(/^[0-9]+$/, '숫자만 입력 가능합니다.')
+    .length(11, '휴대폰 번호는 11자리여야 합니다.')
+    .test(
+      'is-valid-phone-prefix',
+      '휴대폰 번호는 010으로 시작해야 합니다.',
+      (value) => {
+        return value ? value.startsWith('010') : true;
+      },
+    ),
+});

--- a/src/components/SingleForm/ProfileForm/ProfileForm.tsx
+++ b/src/components/SingleForm/ProfileForm/ProfileForm.tsx
@@ -4,7 +4,6 @@ import {
   ProfileFormContainer,
   ProfileTitleContainer,
 } from './ProfileForm.styled';
-import { register } from 'module';
 import SingleValidator from '@/components/Validator/SingleValidator';
 
 const ProfileForm = forwardRef<HTMLTextAreaElement, ProfileFormProps>(

--- a/src/components/SingleForm/SelectForm/SelectForm.tsx
+++ b/src/components/SingleForm/SelectForm/SelectForm.tsx
@@ -1,5 +1,5 @@
 import SelectedBtn from '@/components/Button/SelectedBtn';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   FieldInputFormBox,
   SelectFormBtnContainer,
@@ -9,7 +9,7 @@ import {
 import { SelectFormProps } from '@/types/form/selectForm';
 import { sFieldAtom, selectedFieldAtom, totalFieldAtom } from '@/stores/senior';
 import { useAtom, useSetAtom } from 'jotai';
-import { useFormContext, FormProvider } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { SELECT_FIELD_TEXT } from '@/constants/field/field';
 
 function SelectForm(props: SelectFormProps) {

--- a/src/components/SuggestModal/SuggestModal.tsx
+++ b/src/components/SuggestModal/SuggestModal.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import Image from 'next/image';
 import x_icon from '../../../public/x_gray.png';
-import Router from 'next/navigation';
-import useModal from '@/hooks/useModal';
-import { createPortal } from 'react-dom';
 import { SMFontGray } from './SuggestModal.styled';
 import NextBtn from '../Button/NextBtn';
-import FullModal from '../Modal/FullModal';
 import { useRouter } from 'next/navigation';
 interface SuggestModalProps {
   modalHandler: () => void;

--- a/src/components/Swiper/Swiper.tsx
+++ b/src/components/Swiper/Swiper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'swiper/css/bundle';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { Navigation, Pagination, Autoplay } from 'swiper/modules';
+import { Autoplay } from 'swiper/modules';
 import SwiperCore from 'swiper';
 import { Img } from './Swiper.styled';
 import 'swiper/css';

--- a/src/components/Validator/SingleValidator/SingleValidator.tsx
+++ b/src/components/Validator/SingleValidator/SingleValidator.tsx
@@ -1,8 +1,6 @@
 import { SingleValidatorProps } from '@/types/validator/singleValidator';
 import { SingleValidatorContainer } from './SingleValidator.styled';
-import Image from 'next/image';
-import alert_x from '../../../../public/alert_x.png';
-import alert_o from '../../../../public/alert_o.png';
+
 function SingleValidator(props: SingleValidatorProps) {
   return (
     <SingleValidatorContainer color={props.textColor}>

--- a/src/hooks/mutations/useCancelMyMentoring.ts
+++ b/src/hooks/mutations/useCancelMyMentoring.ts
@@ -3,8 +3,6 @@ import { useMutation } from '@tanstack/react-query';
 export const useCancelMyMentoring = () => {
   return useMutation({
     mutationFn: cancleMentoring,
-    onSuccess: () => {
-      alert('멘토링 취소를 완료하였습니다!');
-    },
+    onSuccess: () => {},
   });
 };

--- a/src/hooks/mutations/useUpdateSeniorProfile.ts
+++ b/src/hooks/mutations/useUpdateSeniorProfile.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { updateSeniorProfile } from '@/api/senior/updateSeniorProfile';
+
+export const useUpdateSeniorProfile = () => {
+  return useMutation({
+    mutationFn: updateSeniorProfile,
+  });
+};

--- a/src/hooks/useFunnel/index.tsx
+++ b/src/hooks/useFunnel/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useEffect, useState } from 'react';
+import { ReactElement, ReactNode, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Funnel from './Funnel';
 
@@ -16,11 +16,11 @@ interface StepProps<Steps extends StepArray> {
 }
 
 interface RouteFunnel<Steps extends StepArray> {
-  (props: FunnelProps<Steps>): ReactElement;
+  (_props: FunnelProps<Steps>): ReactElement;
 }
 
 interface RouterFunnelStep<Steps extends StepArray> {
-  (props: StepProps<Steps>): ReactElement;
+  (_props: StepProps<Steps>): ReactElement;
 }
 
 interface FunnelOptions<Steps extends StepArray> {

--- a/src/hooks/useKakaoLogin.tsx
+++ b/src/hooks/useKakaoLogin.tsx
@@ -72,7 +72,7 @@ const useKakaoLogin = () => {
               <FullModal
                 modalType="account-reactive"
                 modalHandler={async () => {
-                  const res = await rejoinPatchFetch({
+                  await rejoinPatchFetch({
                     socialId,
                     rejoin: true,
                   }).then((res) => {

--- a/src/hooks/useTutorial.ts
+++ b/src/hooks/useTutorial.ts
@@ -1,4 +1,4 @@
-import { useSetAtom, useAtom } from 'jotai';
+import { useAtom } from 'jotai';
 import useAuth from '@/hooks/useAuth';
 import { useTour } from '@reactour/tour';
 import { isTutorialFinished } from '@/stores/signup';
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 function useTutorial() {
   const [isTutorialFinish, setTutorialFinished] = useAtom(isTutorialFinished);
   const { setIsOpen: setTutorialStepOpen } = useTour();
-  const { getUserType, getAccessToken } = useAuth();
+  const { getUserType } = useAuth();
 
   const setTutorialFinish = async () => {
     const userType = getUserType();

--- a/src/types/button/selectedBtn.ts
+++ b/src/types/button/selectedBtn.ts
@@ -1,5 +1,5 @@
 export interface SelectedBtnProps {
   btnText: string;
   selected: Array<string>;
-  selectHandler: (newSelectedString: string[]) => void;
+  selectHandler: (_newSelectedString: string[]) => void;
 }

--- a/src/types/checkbox/checkbox.ts
+++ b/src/types/checkbox/checkbox.ts
@@ -1,4 +1,4 @@
 export type CheckboxProps = {
   checked: boolean;
-  onChange: (checked: boolean) => void;
+  onChange: (_checked: boolean) => void;
 };

--- a/src/types/dropDown/SearchDropDown.ts
+++ b/src/types/dropDown/SearchDropDown.ts
@@ -1,3 +1,3 @@
 export type SearchDropDownProps = {
-  onChange: (value: string) => void;
+  onChange: (_value: string) => void;
 };

--- a/src/types/form/profileForm.tsx
+++ b/src/types/form/profileForm.tsx
@@ -1,9 +1,9 @@
-import { PrimitiveAtom, SetStateAction } from 'jotai';
+import { SetStateAction } from 'jotai';
 import { ChangeEvent } from 'react';
 
 import { UseFormRegisterReturn } from 'react-hook-form';
 
-type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
+type SetAtom<Args extends any[], Result> = (..._args: Args) => Result;
 
 /** '한 줄' | '여러 줄' 명시하는 부분 */
 export type lineType = 'single' | 'multi';
@@ -20,8 +20,8 @@ export interface ProfileFormProps {
   register?: UseFormRegisterReturn;
   placeholder?: string;
   errorMessage?: string;
-  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onChange?: (_e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   onBlur?: (
-    e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
+    _e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => void;
 }

--- a/src/types/form/textForm.ts
+++ b/src/types/form/textForm.ts
@@ -1,4 +1,3 @@
-import { ComponentPropsWithRef, ComponentPropsWithoutRef } from 'react';
 import { UseFormRegisterReturn } from 'react-hook-form';
 
 export type TextFormTargetAtom = 'lab' | 'professor' | 'keyword';

--- a/src/types/matching/matching.ts
+++ b/src/types/matching/matching.ts
@@ -1,6 +1,6 @@
 import { SetStateAction } from 'jotai';
 
-type SetAtom<Args extends any[], Result> = (...args: Args) => Result;
+type SetAtom<Args extends any[], Result> = (..._args: Args) => Result;
 
 export interface MatchingFormProps {
   title: string;


### PR DESCRIPTION
## 🦝 PR 요약

- 기존 핸드폰 Input필드 유효성 검사 hook form으로 추가
- QA사항 반영

## ✨ PR 상세 내용

- 선배 프로필 업데이트 부분을 mutation으로 관리하도록 수정하였습니다!
- qa사항 중 선배 회원이 멘토링을 받았을 떄 거절 실패, 성공 시 각기 다른 모달이 뜨는 부분이 잠시 사라져있었는데요..이를 수정해두었어요!

(요 부분은 overlaykit가 같은 overlay id를 갖고 있었기에, 모달을 여러 개 띄우는 게 불가능했었는데, 각기 다른 모달을 열 때에는, overlayID를 받도록 수정하였습니다.)

- 불필요한 변수 선언문 , import문도 추가적으로 제거해주었어요!

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
