### PR TITLE
RAC-465 Feature:  api 응답 있을 때, 슬랙 채널로 메시지 보내는 기능 추가

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,7 @@
 import useAuth from '@/hooks/useAuth';
 import findExCode from '@/utils/findExCode';
 import axios, { InternalAxiosRequestConfig } from 'axios';
+import { sendServerErrorMsgToSlack } from './slack/sendSeverError';
 
 const withAuthInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
@@ -33,6 +34,8 @@ withAuthInstance.interceptors.response.use(
     if (findExCode(res.data.code)) {
       removeTokens();
       alert(res.data.message);
+      sendServerErrorMsgToSlack(res);
+
       if (typeof window !== 'undefined') {
         window.location.reload();
       }
@@ -47,4 +50,17 @@ withAuthInstance.interceptors.response.use(
   },
 );
 
+withOutAuthInstance.interceptors.response.use(
+  (res) => {
+    if (findExCode(res.data.code)) {
+      sendServerErrorMsgToSlack(res);
+    }
+
+    return res;
+  },
+  (error) => {
+    console.error('Response error:', error);
+    return Promise.reject(error);
+  },
+);
 export { withAuthInstance, withOutAuthInstance };

--- a/src/api/slack/sendSeverError.ts
+++ b/src/api/slack/sendSeverError.ts
@@ -1,0 +1,31 @@
+import { AxiosResponse } from 'axios';
+import axios from 'axios';
+
+export const sendServerErrorMsgToSlack = async (res: AxiosResponse<any>) => {
+  try {
+    const headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+
+    const payload = {
+      text: `
+        *API 호출 중 오류가 발생했어요*\n
+        *API 오류의 발생 경로:* \n
+        ${res.config.baseURL}/${res.config.url}\n
+        *API Method:* \n
+        ${res.data.code || '정보 없음'}\n
+        *API 응답 메시지:* \n
+        ${res.data.message || '정보 없음'}
+      `,
+    };
+
+    await axios({
+      method: 'post',
+      url: 'https://hooks.slack.com/services/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',
+      data: JSON.stringify(payload),
+      headers: headers,
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};


### PR DESCRIPTION
## 🦝 PR 요약

- api상 오류 발생 시, 슬랙 웹훅을 이용해 채널로 메시지 보내는 기능 추가

## ✨ PR 상세 내용

원래는 Sentry를 달려고 했으나, Sentry의 번들 크기가 상당히 큰점..(정말 너무 커서 추가하는 순간 무지막지하게 번들이 커집니다)
추가로, 지금 원하는 건 `API 실패 시 단순 로깅`정도여서, Sentry는 일단 제외해놓고 생각했어요.

만약 `findExCode`에서 오류 코드가 발견되면, 해당 오류(요청 url, 요청 method, 응답 메시지, 응답 코드)에 상세한 정보를 슬랙 채널로 넘겨줍니다.

axios 인터셉터 단에서 관리하도록 설정해주었어요!

## 🚨 주의 사항

## 📸 스크린샷

<img width="877" alt="image" src="https://github.com/user-attachments/assets/684448e5-5579-4327-9422-229222c2dbb6">

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
