### PR TITLE
RAC-469 Feature : 전역적으로 쓰일 수 있는 토스트 추가

### DIFF
--- a/src/app/apply-wanted-senior/page.tsx
+++ b/src/app/apply-wanted-senior/page.tsx
@@ -13,7 +13,6 @@ import {
 } from './(components)/(steps)';
 import { useWishSeniorApply } from '@/hooks/mutations/useWishSeniorApply';
 import { useRouter } from 'next/navigation';
-import styled from 'styled-components';
 import { overlay } from 'overlay-kit';
 import { useState } from 'react';
 import type { WishSeniorApplyRequest } from '@/api/senior/wishSeniorApply';
@@ -146,4 +145,3 @@ export default function ApplyWantedSeniorPage() {
     </main>
   );
 }
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import GTMAnalytics from '@/components/GA/GTM';
 import GoogleAnalytics from '@/components/GA/GA';
 import { SERVICE_METADATA } from '@/constants/meta/metaData';
 import OverlayKitProvider from '@/lib/overlay';
+import { ToastProvider } from '@/components/Toast/ToastProvider';
 
 export const metadata: Metadata = {
   title: SERVICE_METADATA.title,
@@ -80,6 +81,7 @@ export default function RootLayout({
               <div id="senior-auth-portal"></div>
               <div id=" mentoring-cancel-success"></div>
             </OverlayKitProvider>
+            <ToastProvider />
           </StyledComponentsRegistry>
         </Providers>
       </body>

--- a/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
+++ b/src/components/Bar/TapBar/JuniorTab/JTabBar.tsx
@@ -16,7 +16,6 @@ import { tapType } from '@/types/tap/tap';
 import { TAB } from '@/constants/tab/ctap';
 import MentoringApply from '@/components/Mentoring/MentoringApply/MentoringApply';
 import ModalBtn from '@/components/Button/ModalBtn';
-import useModal from '@/hooks/useModal';
 import useDimmedModal from '@/hooks/useDimmedModal';
 import { ModalMentoringType } from '@/types/modal/mentoringDetail';
 

--- a/src/components/DropDown/common/index.ts
+++ b/src/components/DropDown/common/index.ts
@@ -1,7 +1,7 @@
 import { Dropdown as DropDown } from './DropDown';
 import { TriggerButton } from './TriggerButton';
 import { DropdownHeader } from './DropdownHeader';
-import { DropdownList } from './\bDropdownMenu';
+import { DropdownList } from './DropdownMenu';
 import { DropdownItem } from './DropdownItem';
 
 export const Dropdown = {

--- a/src/components/Toast/ToastMessage.tsx
+++ b/src/components/Toast/ToastMessage.tsx
@@ -12,5 +12,13 @@ export function ToastMessage({ message, status }: observerProp) {
     }
   };
 
-  return <div className={`toast-message ${getStatusClass()}`}>{message}</div>;
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`toast-message ${getStatusClass()}`}
+    >
+      {message}
+    </div>
+  );
 }

--- a/src/components/Toast/ToastMessage.tsx
+++ b/src/components/Toast/ToastMessage.tsx
@@ -1,0 +1,16 @@
+import { observerProp } from './ToastService';
+import './index.css';
+export function ToastMessage({ message, status }: observerProp) {
+  const getStatusClass = () => {
+    switch (status) {
+      case 'success':
+        return 'toast-success';
+      case 'error':
+        return 'toast-error';
+      default:
+        return '';
+    }
+  };
+
+  return <div className={`toast-message ${getStatusClass()}`}>{message}</div>;
+}

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -23,7 +23,7 @@ export function ToastProvider() {
       setMessage((prev) => [
         ...prev,
         {
-          id: Date.now().toLocaleString(),
+          id: crypto.randomUUID(),
           message: props.message,
           status: props.status,
         },

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -29,9 +29,10 @@ export function ToastProvider() {
         },
       ]);
 
-      setTimeout(() => {
+      const timerId = setTimeout(() => {
         setMessage((prev) => prev.slice(1));
       }, 2000);
+      return () => clearTimeout(timerId);
     };
     singleToastService.subscribe(addNewToastMessage);
     return () => singleToastService.unsubscribe(addNewToastMessage);

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -16,8 +16,8 @@ export function ToastProvider() {
     const singleToastService = ToastService.getInstance();
 
     const addNewToastMessage = (props: observerProp) => {
-      if (message.length > 2) {
-        return;
+      if (message.length >= 2) {
+        setMessage(prev => prev.slice(1));
       }
 
       setMessage((prev) => [

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ToastService } from './ToastService';
+import { observerProp } from './ToastService';
+import { ToastMessage } from './ToastMessage';
+
+interface message extends observerProp {
+  id: string;
+}
+
+export function ToastProvider() {
+  const [message, setMessage] = useState<message[]>([]);
+
+  useEffect(() => {
+    const singleToastService = ToastService.getInstance();
+
+    const addNewToastMessage = (props: observerProp) => {
+      if (message.length > 2) {
+        return;
+      }
+
+      setMessage((prev) => [
+        ...prev,
+        {
+          id: Date.now().toLocaleString(),
+          message: props.message,
+          status: props.status,
+        },
+      ]);
+
+      setTimeout(() => {
+        setMessage((prev) => prev.slice(1));
+      }, 2000);
+    };
+    singleToastService.subscribe(addNewToastMessage);
+    return () => singleToastService.unsubscribe(addNewToastMessage);
+  }, [message.length]);
+
+  return (
+    <>
+      {message.map((ms, index) => (
+        <ToastMessage key={index} status={ms.status} message={ms.message} />
+      ))}
+    </>
+  );
+}

--- a/src/components/Toast/ToastService.tsx
+++ b/src/components/Toast/ToastService.tsx
@@ -1,0 +1,42 @@
+export interface observerProp {
+  message: string;
+  status: 'error' | 'success';
+}
+
+export class ToastService {
+  private static instance: ToastService | null = null;
+
+  private observers: any[] = [];
+  private messages: observerProp[] = [];
+
+  private constructor() {}
+
+  public static getInstance(): ToastService {
+    if (!ToastService.instance) {
+      ToastService.instance = new ToastService();
+    }
+    return ToastService.instance;
+  }
+
+  subscribe(observer: (props: observerProp) => void) {
+    this.observers.push(observer);
+  }
+
+  unsubscribe(observer: (props: observerProp) => void) {
+    this.observers = this.observers.filter((obs) => obs !== observer);
+  }
+
+  notify() {
+    this.observers.forEach((obs) =>
+      obs(this.messages[this.messages.length - 1]),
+    );
+  }
+
+  addToast(props: observerProp) {
+    if (this.messages.length > 2) {
+      this.messages.shift();
+    }
+    this.messages.push(props);
+    this.notify();
+  }
+}

--- a/src/components/Toast/ToastService.tsx
+++ b/src/components/Toast/ToastService.tsx
@@ -6,7 +6,7 @@ export interface observerProp {
 export class ToastService {
   private static instance: ToastService | null = null;
 
-  private observers: any[] = [];
+  private observers: Array<(props: observerProp) => void> = [];
   private messages: observerProp[] = [];
 
   private constructor() {}

--- a/src/components/Toast/index.css
+++ b/src/components/Toast/index.css
@@ -1,0 +1,25 @@
+.toast-message {
+  position: fixed;
+  bottom: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 16px;
+  margin: 0 auto;
+  border-radius: 8px;
+  transition:
+    transform 0.3s ease,
+    opacity 0.3s ease;
+  opacity: 1;
+  width: 360px;
+  z-index: 1000;
+}
+
+.toast-success {
+  background-color: #2fc4b2;
+  color: white;
+}
+
+.toast-error {
+  background-color: #ff5757;
+  color: white;
+}

--- a/src/components/Toast/index.css
+++ b/src/components/Toast/index.css
@@ -1,6 +1,6 @@
 .toast-message {
   position: fixed;
-  bottom: 30px;
+  bottom: 80px;
   left: 50%;
   transform: translateX(-50%);
   padding: 16px;
@@ -20,6 +20,8 @@
 }
 
 .toast-error {
-  background-color: #ff5757;
-  color: white;
+  background-color: #fff5f3;
+  color: #2f3f53;
+  border-radius: 8px;
+  border: 1px solid #f4b0a1;
 }

--- a/src/hooks/mutations/useConfirmSeniorMentoring.ts
+++ b/src/hooks/mutations/useConfirmSeniorMentoring.ts
@@ -1,4 +1,4 @@
-import { confirmSeniorMentoring } from '@/api/mentoring/\bconfirmSeniorMentoring';
+import { confirmSeniorMentoring } from '@/api/mentoring/confirmSeniorMentoring';
 import { useMutation } from '@tanstack/react-query';
 
 export const useConfirmSeniorMentoring = () => {

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,11 @@
+import { observerProp, ToastService } from '@/components/Toast/ToastService';
+
+export function useToast() {
+  function addToast({ message, status }: observerProp) {
+    ToastService.getInstance().addToast({ message, status });
+  }
+
+  return {
+    addToast,
+  };
+}


### PR DESCRIPTION
## 🦝 PR 요약

- mutate시 에러 상태 표시를 위한 토스트 추가

## ✨ PR 상세 내용

- 에러를 표시하기 위한 토스트 ui를 추가해주었습니다.
- Contextn나 jotai를 써도 되지만, Context를 사용할 경우, 재렌더링과 그 흐름 추적을 하기 생각보다 빡세더라구요.. 또 전역상태를 사용하고 싶지 않아서 옵저버 패턴을 사용해서 구현해보았습니다.
- axios instance단에서 응답으로 오는 것들 중에 ExCode가 포함된 경우 토스트를 띄워줍니다!

```tsx

export class ToastService {
  private static instance: ToastService | null = null;

  private observers: any[] = [];
  private messages: observerProp[] = [];

  private constructor() {}

  public static getInstance(): ToastService {
    if (!ToastService.instance) {
      ToastService.instance = new ToastService();
    }
    return ToastService.instance;
  }

  subscribe(observer: (props: observerProp) => void) {
    this.observers.push(observer);
  }

  unsubscribe(observer: (props: observerProp) => void) {
    this.observers = this.observers.filter((obs) => obs !== observer);
  }

  notify() {
    this.observers.forEach((obs) =>
      obs(this.messages[this.messages.length - 1]),
    );
  }

  addToast(props: observerProp) {
    if (this.messages.length > 2) {
      this.messages.shift();
    }
    this.messages.push(props);
    this.notify();
  }
}
```

요 글을 많이 참고했어요 https://velog.io/@minsu8834/Observer-pattern-with-Toast-Modal
생각보다 옵저버 패턴으로 전역적인 무언가를 하는 ui를 구현하는 것도 괜찮은 방법..?이지 않을까 싶었어요..

구현하면서 많이 배웠슴니다

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
