### PR TITLE
hotfix: 페이팔 계좌 연동 제거에 따른 라우팅 접근 방지, 멘토링 신청 버튼으로 이동하지 못하게 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-const { withSentryConfig } = require('@sentry/nextjs');
-
 const nextConfig = {
   swcMinify: true,
   reactStrictMode: false,
@@ -12,21 +10,4 @@ const nextConfig = {
   },
 };
 
-const isProduction = process.env.NODE_ENV === 'production';
-
-const sentryOptions = {
-  org: 'raccons',
-  project: 'postgradu',
-  silent: !process.env.CI,
-  widenClientFileUpload: true,
-  tunnelRoute: '/monitoring',
-  hideSourceMaps: true,
-  disableLogger: true,
-  automaticVercelMonitors: true,
-};
-
-const config = isProduction
-  ? withSentryConfig(nextConfig, sentryOptions)
-  : nextConfig;
-
-module.exports = config;
+module.exports = nextConfig;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,9 +1,6 @@
 import useAuth from '@/hooks/useAuth';
 import findExCode from '@/utils/findExCode';
 import axios, { InternalAxiosRequestConfig } from 'axios';
-import { sendServerErrorMsgToSlack } from './slack/sendSeverError';
-import { captureException } from '@sentry/nextjs';
-
 const withAuthInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
 });
@@ -33,17 +30,8 @@ withAuthInstance.interceptors.response.use(
   (res) => {
     const { removeTokens } = useAuth();
     if (findExCode(res.data.code)) {
-      captureException(res.data.code, {
-        level: 'error',
-        extra: {
-          header: res.config.headers,
-          request: res.request,
-          type: 'Network Error!',
-        },
-      });
       removeTokens();
       alert(res.data.message);
-      sendServerErrorMsgToSlack(res);
 
       if (typeof window !== 'undefined') {
         window.location.reload();
@@ -62,7 +50,7 @@ withAuthInstance.interceptors.response.use(
 withOutAuthInstance.interceptors.response.use(
   (res) => {
     if (findExCode(res.data.code)) {
-      sendServerErrorMsgToSlack(res);
+      alert(res.data.message);
     }
 
     return res;

--- a/src/app/senior/info/[seniorId]/SeniorInfo.tsx
+++ b/src/app/senior/info/[seniorId]/SeniorInfo.tsx
@@ -115,13 +115,15 @@ export function SeniorInfoPage({ params }: { params: { seniorId: string } }) {
             </div>
           </SeniorInfoContent>
         </SeniorInfoContentWrapper>
-        {isMine ? (
+        {/*
+{isMine ? (
           <MentoringApplyBtn onClick={editHandler}>수정하기</MentoringApplyBtn>
         ) : (
           <MentoringApplyBtn onClick={applyHandler}>
             멘토링 신청
           </MentoringApplyBtn>
         )}
+*/}
       </SeniorInfoPageContainer>
     </ErrorBoundary>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  console.log(request);
+  if (request.nextUrl.pathname.includes('mentoring-apply')) {
+    return NextResponse.redirect(new URL('/', request.url));
+  } else {
+    return NextResponse.next();
+  }
+}
+
+export const config = {
+  matcher: ['/mentoring-apply/:path*'],
+};


### PR DESCRIPTION
## 🦝 PR 요약

페이팔 해지에 따른 결제 관련 라우팅 접근 방지

## ✨ PR 상세 내용

## 🚨 주의 사항

## 📸 스크린샷

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [ ] `npm run format:fix` 실행했나요?
